### PR TITLE
Symbols and macro keyword patterns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject carocad/parcera "0.3.0"
+(defproject carocad/parcera "0.3.1"
   :description "Grammar-based Clojure(script) parser"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"

--- a/src/parcera/terminals.cljc
+++ b/src/parcera/terminals.cljc
@@ -1,15 +1,14 @@
 (ns parcera.terminals)
 
-; todo: anchor ALL to the beginning of string
 ; todo: try to avoid lookahead
 
 ;; Clojure's reader is quite permissive so we follow the motto "if it is not forbidden, it is allowed"
 ; todo: dont allow /
-(def NAME "[^\\s\\(\\)\\[\\]{}\"@~\\^;`\\\\]+")
+(def NAME "[^\\s\\(\\)\\[\\]{}\"@~\\^;`\\\\\\/]+")
 ; todo: (?!\/) do i need that ?
 ;; symbols cannot start with a number, :, # nor '
 ; todo: no need for negative lookahead of chars
-(def symbol-pattern (str "(?![:#\\',]|[+-]?\\d+)(" NAME "\\/)?(\\/|(" NAME "))"))
+(def symbol-pattern (str "(?![:#\\',]|[+-]?\\d+)(" NAME "\\/)?(\\/|(" NAME "))(?=[\\s\"()\\[\\]{}]|$)"))
 
 (def double-suffix "(((\\.\\d*)?([eE][-+]?\\d+)?)M?)")
 (def long-suffix "((0[xX]([\\dA-Fa-f]+)|0([0-7]+)|([1-9]\\d?)[rR]([\\d\\w]+)|0\\d+)?N?)")

--- a/src/parcera/terminals.cljc
+++ b/src/parcera/terminals.cljc
@@ -1,4 +1,8 @@
-(ns parcera.terminals)
+(ns parcera.terminals
+  "Clojure symbols, keywords, numbers and string/regex share quite a lot
+  of matching logic. This namespace is aimed towards clearly identifying
+  those pieces and share them among the different definitions to
+  avoid recurring issues")
 
 ;; Clojure's reader is quite permissive so we follow the motto
 ;; "if it is not forbidden, it is allowed"
@@ -14,7 +18,11 @@
          "(\\/|(" first-character allowed-characters "))"
          symbol-end)))
 
+
 (def symbol-pattern (str not-number (name-pattern ":#\\'")))
+(def simple-keyword (str ":" (name-pattern ":")))
+(def macro-keyword (str "::" (name-pattern ":")))
+
 
 (def double-suffix "(((\\.\\d*)?([eE][-+]?\\d+)?)M?)")
 (def long-suffix "((0[xX]([\\dA-Fa-f]+)|0([0-7]+)|([1-9]\\d?)[rR]([\\d\\w]+)|0\\d+)?N?)")
@@ -32,12 +40,6 @@
 (def unicode "(u[\\dD-Fd-f]{4})")
 ; todo: use word boundary to avoid lookahead
 (def character-pattern (str "\\\\(" unicode-char "|" named-char "|" unicode ")(?!\\w+)"))
-
-
-; : is not allowed as first keyword character
-; todo: no need for negative lookahead of symbol
-(def simple-keyword (str ":" (name-pattern ":")))
-(def macro-keyword (str "::" (name-pattern ":")))
 
 
 (def string-pattern "\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"")

--- a/src/parcera/terminals.cljc
+++ b/src/parcera/terminals.cljc
@@ -2,12 +2,19 @@
 
 ;; Clojure's reader is quite permissive so we follow the motto
 ;; "if it is not forbidden, it is allowed"
-(def NAME "[^\\s\\(\\)\\[\\]{}\"@~\\^;`\\\\\\/,]+")
-;; symbols cannot start with a number, :, # nor '
-; todo: no need for negative lookahead of chars
-(def first-character "(?![:#\\',]|[+-]?\\d+)")
+(def not-allowed "\\s\\(\\)\\[\\]{}\"@~\\^;`\\\\\\/,")
+(def allowed-characters (str "[^" not-allowed "]*"))
+(def not-number "(?![+-]?\\d+)")
 (def symbol-end "(?=[\\s\"()\\[\\]{},]|$)")
-(def symbol-pattern (str first-character "(" NAME "\\/)?(\\/|(" NAME "))" symbol-end))
+
+(defn- name-pattern
+  [restriction]
+  (let [first-character (str "[^" restriction not-allowed "]")]
+    (str "(" first-character allowed-characters "\\/)?"
+         "(\\/|(" first-character allowed-characters "))"
+         symbol-end)))
+
+(def symbol-pattern (str not-number (name-pattern ":#\\'")))
 
 (def double-suffix "(((\\.\\d*)?([eE][-+]?\\d+)?)M?)")
 (def long-suffix "((0[xX]([\\dA-Fa-f]+)|0([0-7]+)|([1-9]\\d?)[rR]([\\d\\w]+)|0\\d+)?N?)")
@@ -29,8 +36,8 @@
 
 ; : is not allowed as first keyword character
 ; todo: no need for negative lookahead of symbol
-(def simple-keyword (str ":(?!:)" symbol-pattern))
-(def macro-keyword (str "::(?!:)" symbol-pattern))
+(def simple-keyword (str ":" (name-pattern ":")))
+(def macro-keyword (str "::" (name-pattern ":")))
 
 
 (def string-pattern "\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"")

--- a/src/parcera/terminals.cljc
+++ b/src/parcera/terminals.cljc
@@ -1,14 +1,13 @@
 (ns parcera.terminals)
 
-; todo: try to avoid lookahead
-
-;; Clojure's reader is quite permissive so we follow the motto "if it is not forbidden, it is allowed"
-; todo: dont allow /
+;; Clojure's reader is quite permissive so we follow the motto
+;; "if it is not forbidden, it is allowed"
 (def NAME "[^\\s\\(\\)\\[\\]{}\"@~\\^;`\\\\\\/,]+")
-; todo: (?!\/) do i need that ?
 ;; symbols cannot start with a number, :, # nor '
 ; todo: no need for negative lookahead of chars
-(def symbol-pattern (str "(?![:#\\',]|[+-]?\\d+)(" NAME "\\/)?(\\/|(" NAME "))(?=[\\s\"()\\[\\]{},]|$)"))
+(def first-character "(?![:#\\',]|[+-]?\\d+)")
+(def symbol-end "(?=[\\s\"()\\[\\]{},]|$)")
+(def symbol-pattern (str first-character "(" NAME "\\/)?(\\/|(" NAME "))" symbol-end))
 
 (def double-suffix "(((\\.\\d*)?([eE][-+]?\\d+)?)M?)")
 (def long-suffix "((0[xX]([\\dA-Fa-f]+)|0([0-7]+)|([1-9]\\d?)[rR]([\\d\\w]+)|0\\d+)?N?)")

--- a/src/parcera/terminals.cljc
+++ b/src/parcera/terminals.cljc
@@ -35,7 +35,7 @@
 ; It's cooked by this generator: http://kourge.net/projects/regexp-unicode-block
 ; ticking all 'Combining Diacritical Marks' boxes *))
 ; todo: repeated pattern could be simplified
-(def unicode-char "([^\\u0300-\\u036F\\u1DC0-\\u1DFF\\u20D0-\\u20FF][\\u0300-\\u036F\\u1DC0-\\u1DFF\\u20D0-\\u20FF]*)")
+(def unicode-char "([^\\u0300-\\u036F\\u1DC0-\\u1DFF\\u20D0-\\u20FF])")
 (def named-char "(newline|return|space|tab|formfeed|backspace)")
 (def unicode "(u[\\dD-Fd-f]{4})")
 ; todo: use word boundary to avoid lookahead

--- a/src/parcera/terminals.cljc
+++ b/src/parcera/terminals.cljc
@@ -34,11 +34,9 @@
 ; mentioned here: https://www.regular-expressions.info/unicode.html
 ; It's cooked by this generator: http://kourge.net/projects/regexp-unicode-block
 ; ticking all 'Combining Diacritical Marks' boxes *))
-; todo: repeated pattern could be simplified
 (def unicode-char "([^\\u0300-\\u036F\\u1DC0-\\u1DFF\\u20D0-\\u20FF])")
 (def named-char "(newline|return|space|tab|formfeed|backspace)")
 (def unicode "(u[\\dD-Fd-f]{4})")
-; todo: use word boundary to avoid lookahead
 (def character-pattern (str "\\\\(" unicode-char "|" named-char "|" unicode ")(?!\\w+)"))
 
 

--- a/src/parcera/terminals.cljc
+++ b/src/parcera/terminals.cljc
@@ -31,7 +31,7 @@
 ; : is not allowed as first keyword character
 ; todo: no need for negative lookahead of symbol
 (def simple-keyword (str ":(?!:)" symbol-pattern))
-(def macro-keyword (str "::(?!:)" NAME))
+(def macro-keyword (str "::(?!:)" symbol-pattern))
 
 
 (def string-pattern "\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"")

--- a/src/parcera/terminals.cljc
+++ b/src/parcera/terminals.cljc
@@ -4,11 +4,11 @@
 
 ;; Clojure's reader is quite permissive so we follow the motto "if it is not forbidden, it is allowed"
 ; todo: dont allow /
-(def NAME "[^\\s\\(\\)\\[\\]{}\"@~\\^;`\\\\\\/]+")
+(def NAME "[^\\s\\(\\)\\[\\]{}\"@~\\^;`\\\\\\/,]+")
 ; todo: (?!\/) do i need that ?
 ;; symbols cannot start with a number, :, # nor '
 ; todo: no need for negative lookahead of chars
-(def symbol-pattern (str "(?![:#\\',]|[+-]?\\d+)(" NAME "\\/)?(\\/|(" NAME "))(?=[\\s\"()\\[\\]{}]|$)"))
+(def symbol-pattern (str "(?![:#\\',]|[+-]?\\d+)(" NAME "\\/)?(\\/|(" NAME "))(?=[\\s\"()\\[\\]{},]|$)"))
 
 (def double-suffix "(((\\.\\d*)?([eE][-+]?\\d+)?)M?)")
 (def long-suffix "((0[xX]([\\dA-Fa-f]+)|0([0-7]+)|([1-9]\\d?)[rR]([\\d\\w]+)|0\\d+)?N?)")

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -203,9 +203,9 @@
                                               (is (clear input)))))
 
   (testing "keyword"
-    (as-> "::hello/world [1 a \"3\"]" input (and (is (valid? input))
-                                                 (is (roundtrip input))
-                                                 (is (clear input))))
+    (as-> "::hello [1 a \"3\"]" input (and (is (valid? input))
+                                           (is (roundtrip input))
+                                           (is (clear input))))
     (as-> "::hello" input (and (is (valid? input))
                                (is (roundtrip input))
                                (is (clear input)))))

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -132,7 +132,11 @@
     (as-> "{:hello ;2}
            2}" input (and (is (valid? input))
                           (is (roundtrip input))
-                          (is (clear input))))))
+                          (is (clear input)))))
+  (testing "symbols"
+    (as-> "hello/world/" input (is (not (valid? input))))
+    (as-> ":hello/world/" input (is (not (valid? input))))
+    (as-> "::hello/world/" input (is (not (valid? input))))))
 
 
 (deftest macros

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -203,9 +203,9 @@
                                               (is (clear input)))))
 
   (testing "keyword"
-    (as-> "::hello [1 a \"3\"]" input (and (is (valid? input))
-                                           (is (roundtrip input))
-                                           (is (clear input))))
+    (as-> "::hello/world [1 a \"3\"]" input (and (is (valid? input))
+                                                 (is (roundtrip input))
+                                                 (is (clear input))))
     (as-> "::hello" input (and (is (valid? input))
                                (is (roundtrip input))
                                (is (clear input)))))


### PR DESCRIPTION
- fix: `hello/world/` symbol did match but shouldnt
- fix: `::hello/world` macro keyword should match but didnt
- fix: `hello/wo,rld` symbol match but shouldnt