### PR TITLE
Handle parse failures in `failure`

### DIFF
--- a/src/clojure/parcera/core.cljc
+++ b/src/clojure/parcera/core.cljc
@@ -22,7 +22,8 @@
   [rule children metadata]
   (case rule
     (:symbol :simple_keyword :macro_keyword)
-    (when (nil? (re-find name-pattern (first children)))
+    (when (and (string? (first children))
+               (nil? (re-find name-pattern (first children))))
       (with-meta (list ::failure (cons rule children))
                  (assoc-in metadata [::start :message]
                            (str "name cannot contain more than one /"))))


### PR DESCRIPTION
When a parse failure occurs, instead of a string the keyword will be
made up of a list.  This list fails during re-find, and makes the AST
generation process fail.  As generation is lazy, this is particularly
difficult to debug.