### PR TITLE
name validation extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ this dependency will be in the classpath to avoid collisions.
 
 ;; get meta data from the parsed code
 (meta (second (parcera/ast (str :hello))))
-
+#:parcera.core{:start {:row 1, :column 0}, :end {:row 1, :column 6}}
 
 ;; convert an AST back into a string
 (parcera/code [:symbol "ns"])

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ this dependency will be in the classpath to avoid collisions.
    (:whitespace " ")
    (:vector (:symbol "clojure.string") (:whitespace " ") (:simple_keyword "as") (:whitespace " ") (:symbol "str")))))
 
+
+;; get meta data from the parsed code
+(meta (second (parcera/ast (str :hello))))
+
+
 ;; convert an AST back into a string
 (parcera/code [:symbol "ns"])
 ;; "ns"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject carocad/parcera "0.5.1"
+(defproject carocad/parcera "0.5.2"
   :description "Grammar-based Clojure parser"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -32,7 +32,11 @@ map: '{' form* '}';
 
 literal: keyword | string | number | character | symbol;
 
-keyword: KEYWORD;
+keyword: simple_keyword | macro_keyword;
+
+simple_keyword: SIMPLE_KEYWORD;
+
+macro_keyword: MACRO_KEYWORD;
 
 string: STRING;
 
@@ -118,8 +122,9 @@ SPACE: [\r\n\t\f, ]+;
 
 CHARACTER: '\\' (UNICODE_CHAR | NAMED_CHAR | UNICODE);
 
-// either a qualified keyword or a simple one
-KEYWORD: ':' ':'? KEYWORD_HEAD SYMBOL_BODY*;
+MACRO_KEYWORD: '::' KEYWORD_HEAD SYMBOL_BODY*;
+
+SIMPLE_KEYWORD: ':' KEYWORD_HEAD SYMBOL_BODY*;
 
 SYMBOL: NAME_HEAD SYMBOL_BODY*;
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -33,7 +33,14 @@ map: '{' form* '}';
 literal: keyword | string | number | character | symbol;
 
 keyword: simple_keyword | macro_keyword;
-
+/**
+ * keywords are treated like symbols prepended by : this was 'borrowed' from
+ * Clojure's Lisp Reader which uses a single regex to match both and then
+ * checks if it starts with :
+ *
+ * I am not fully sure if it would be better to make keywords Lexer rules but
+ * at least for the time being this approach seems to work quite well
+ */
 simple_keyword: ':' (NAME | NUMBER);
 
 macro_keyword: '::' (NAME | NUMBER);
@@ -122,8 +129,10 @@ SPACE: [\r\n\t\f, ]+;
 
 CHARACTER: '\\' (UNICODE_CHAR | NAMED_CHAR | UNICODE);
 
-// note: certain patterns are allowed on purpose because it would be too difficult
-// to validate those with antlr; parcera takes care of those special cases
+/**
+ * note: certain patterns are allowed on purpose because it would be too difficult
+ * to validate those with antlr; parcera takes care of those special cases
+ */
 NAME: NAME_HEAD NAME_BODY*;
 
 fragment UNICODE_CHAR: ~[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF];

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -32,13 +32,7 @@ map: '{' form* '}';
 
 literal: keyword | string | number | character | symbol;
 
-keyword: simple_keyword | macro_keyword;
-
-// making symbols, simple and macro keywords be based on NAME allows to
-// conform them all in the same way (see `conform` function)
-simple_keyword: ':' NAME;
-
-macro_keyword: '::' NAME;
+keyword: KEYWORD;
 
 string: STRING;
 
@@ -46,7 +40,7 @@ number: NUMBER;
 
 character: CHARACTER;
 
-symbol: NAME;
+symbol: SYMBOL;
 
 reader_macro: ( unquote
               | metadata
@@ -124,7 +118,10 @@ SPACE: [\r\n\t\f, ]+;
 
 CHARACTER: '\\' (UNICODE_CHAR | NAMED_CHAR | UNICODE);
 
-NAME: NAME_HEAD NAME_BODY*;
+// either a qualified keyword or a simple one
+KEYWORD: ':' ':'? KEYWORD_HEAD SYMBOL_BODY*;
+
+SYMBOL: NAME_HEAD SYMBOL_BODY*;
 
 fragment UNICODE_CHAR: ~[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF];
 
@@ -132,8 +129,11 @@ fragment NAMED_CHAR: 'newline' | 'return' | 'space' | 'tab' | 'formfeed' | 'back
 
 fragment UNICODE: 'u' [0-9d-fD-F] [0-9d-fD-F] [0-9d-fD-F] [0-9d-fD-F];
 
-// re-allow :#' as valid characters inside the name itself
-fragment NAME_BODY: NAME_HEAD | [:#'0-9];
+// symbols can contain : as part of their names
+fragment SYMBOL_BODY: KEYWORD_HEAD | [:];
+
+// the first character of a keyword cannot be :
+fragment KEYWORD_HEAD: NAME_HEAD | [#'0-9];
 
 // these is the set of characters that are allowed by all symbols and keywords
 // however, this is more strict that necessary so that we can re-use it for both

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -34,9 +34,9 @@ literal: keyword | string | number | character | symbol;
 
 keyword: simple_keyword | macro_keyword;
 
-simple_keyword: SIMPLE_KEYWORD;
+simple_keyword: ':' (NAME | NUMBER);
 
-macro_keyword: MACRO_KEYWORD;
+macro_keyword: '::' (NAME | NUMBER);
 
 string: STRING;
 
@@ -44,7 +44,7 @@ number: NUMBER;
 
 character: CHARACTER;
 
-symbol: SYMBOL;
+symbol: NAME;
 
 reader_macro: ( unquote
               | metadata
@@ -122,11 +122,9 @@ SPACE: [\r\n\t\f, ]+;
 
 CHARACTER: '\\' (UNICODE_CHAR | NAMED_CHAR | UNICODE);
 
-MACRO_KEYWORD: '::' KEYWORD_HEAD SYMBOL_BODY*;
-
-SIMPLE_KEYWORD: ':' KEYWORD_HEAD SYMBOL_BODY*;
-
-SYMBOL: NAME_HEAD SYMBOL_BODY*;
+// note: certain patterns are allowed on purpose because it would be too difficult
+// to validate those with antlr; parcera takes care of those special cases
+NAME: NAME_HEAD NAME_BODY*;
 
 fragment UNICODE_CHAR: ~[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF];
 
@@ -134,15 +132,12 @@ fragment NAMED_CHAR: 'newline' | 'return' | 'space' | 'tab' | 'formfeed' | 'back
 
 fragment UNICODE: 'u' [0-9d-fD-F] [0-9d-fD-F] [0-9d-fD-F] [0-9d-fD-F];
 
-// symbols can contain : as part of their names
-fragment SYMBOL_BODY: KEYWORD_HEAD | [:];
-
-// the first character of a keyword cannot be :
-fragment KEYWORD_HEAD: NAME_HEAD | [#'0-9];
+// symbols can contain : # ' as part of their names
+fragment NAME_BODY: NAME_HEAD | [#':0-9];
 
 // these is the set of characters that are allowed by all symbols and keywords
 // however, this is more strict that necessary so that we can re-use it for both
-fragment NAME_HEAD: ~[\r\n\t\f ()[\]{}"@~^;`\\,:#'0-9];
+fragment NAME_HEAD: ~[\r\n\t\f ()[\]{}"@~^;`\\,:#'];
 
 fragment DOUBLE_SUFFIX: ((('.' DIGIT*)? ([eE][-+]?DIGIT+)?) 'M'?);
 

--- a/src/clojure/parcera/core.cljc
+++ b/src/clojure/parcera/core.cljc
@@ -22,7 +22,9 @@
   [rule children metadata]
   (case rule
     (:symbol :simple_keyword :macro_keyword)
-    (when (nil? (re-find name-pattern (first children)))
+    ;; when keywords fail on lexer they become ((::failure "message") "rest")
+    (when (and (not= ::failure (ffirst children))
+               (nil? (re-find name-pattern (first children))))
       (with-meta (list ::failure (cons rule children))
                  (assoc-in metadata [::start :message]
                            (str "name cannot contain more than one /"))))

--- a/src/clojure/parcera/core.cljc
+++ b/src/clojure/parcera/core.cljc
@@ -12,8 +12,8 @@
 
 
 ;; for some reason cljs doesnt accept escaping the / characters
-(def name-pattern #?(:clj  #"^([^\s\/]+\/)?(\/|[^\s\/]+)$"
-                     :cljs #"^([^\s/]+/)?(/|[^\s/]+)$"))
+(def name-pattern #?(:clj  #"^:?:?([^\s\/]+\/)?(\/|[^\s\/]+)$"
+                     :cljs #"^:?:?([^\s/]+/)?(/|[^\s/]+)$"))
 
 
 (defn- failure
@@ -140,7 +140,7 @@
         (doseq [child (rest ast)] (code* child string-builder))
         (. string-builder (append "}")))
 
-    (:number :whitespace :symbol :character :string)
+    (:number :whitespace :symbol :character :string :simple_keyword :macro_keyword)
     (. string-builder (append (second ast)))
 
     :symbolic
@@ -153,14 +153,6 @@
 
     :auto_resolve
     (. string-builder (append "::"))
-
-    :simple_keyword
-    (do (. string-builder (append ":"))
-        (. string-builder (append (second ast))))
-
-    :macro_keyword
-    (do (. string-builder (append "::"))
-        (. string-builder (append (second ast))))
 
     :metadata
     (do (doseq [child (rest (butlast ast))] (code* child string-builder))

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -222,7 +222,15 @@
   (testing "tag literals"
     ;; nested tag literals
     (let [input "#a #b 1"]
-      (is (valid? input)))))
+      (is (valid? input))
+      (is (not (valid? input)))))
+
+  (testing "keywords"
+    ;; a keyword can be a simple number because its first character is : which is
+    ;; NOT a number ;)
+    (let [input ":1"]
+      (is (valid? input))
+      (is (roundtrip input)))))
 
 
 (deftest macros

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -222,8 +222,7 @@
   (testing "tag literals"
     ;; nested tag literals
     (let [input "#a #b 1"]
-      (is (valid? input))
-      (is (not (valid? input)))))
+      (is (valid? input))))
 
   (testing "keywords"
     ;; a keyword can be a simple number because its first character is : which is

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -230,7 +230,10 @@
     ;; NOT a number ;)
     (let [input ":1"]
       (is (valid? input))
-      (is (roundtrip input)))))
+      (is (roundtrip input)))
+    ;; ::/ is valid according to parcera's lexer but not for Clojure
+    (let [input "::/"]
+      (is (not (valid? input))))))
 
 
 (deftest macros


### PR DESCRIPTION
- fixes #32 
- allows `number` as a valid keyword instead of just `name`
- forbids `::/` on macro keywords
- forbids `symbols` starting with a `number`