### PR TITLE
fix: leading 0 is not needed as we only care about the suffix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject carocad/parcera "0.5.3"
+(defproject carocad/parcera "0.5.4"
   :description "Grammar-based Clojure parser"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject carocad/parcera "0.5.2"
+(defproject carocad/parcera "0.5.3"
   :description "Grammar-based Clojure parser"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -150,11 +150,12 @@ fragment NAME_HEAD: ~[\r\n\t\f ()[\]{}"@~^;`\\,:#'];
 
 fragment DOUBLE_SUFFIX: ((('.' DIGIT*)? ([eE][-+]?DIGIT+)?) 'M'?);
 
-fragment LONG_SUFFIX: ('0'[xX]((DIGIT|[A-Fa-f])+) |
-                       '0'([0-7]+) |
-                       ([1-9]DIGIT?)[rR](DIGIT[a-zA-Z]+) |
-                       '0'DIGIT+
-                      )?'N'?;
+// check LispReader for the pattern used by Clojure
+// static Pattern intPat = Pattern.compile("([-+]?)(?:(0)|([1-9][0-9]*)|0[xX]([0-9A-Fa-f]+)|0([0-7]+)|([1-9][0-9]?)[rR]([0-9A-Za-z]+)|0[0-9]+)(N)?");
+fragment LONG_SUFFIX: ( [xX](DIGIT|[A-Fa-f])+
+                      | [0-7]+
+                      | [rR]DIGIT[a-zA-Z]+
+                      )? 'N'?;
 
 fragment RATIO_SUFFIX: '/' DIGIT+;
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -151,10 +151,9 @@ fragment NAME_HEAD: ~[\r\n\t\f ()[\]{}"@~^;`\\,:#'];
 fragment DOUBLE_SUFFIX: ((('.' DIGIT*)? ([eE][-+]?DIGIT+)?) 'M'?);
 
 // check LispReader for the pattern used by Clojure
-// static Pattern intPat = Pattern.compile("([-+]?)(?:(0)|([1-9][0-9]*)|0[xX]([0-9A-Fa-f]+)|0([0-7]+)|([1-9][0-9]?)[rR]([0-9A-Za-z]+)|0[0-9]+)(N)?");
-fragment LONG_SUFFIX: ( [xX](DIGIT|[A-Fa-f])+
+fragment LONG_SUFFIX: ( [xX][0-9A-Fa-f]+
                       | [0-7]+
-                      | [rR]DIGIT[a-zA-Z]+
+                      | [rR][0-9a-zA-Z]+
                       )? 'N'?;
 
 fragment RATIO_SUFFIX: '/' DIGIT+;

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -98,7 +98,7 @@ regex: '#' STRING;
 
 set: '#{' form* '}';
 
-namespaced_map: '#' ( keyword |  auto_resolve) map;
+namespaced_map: '#' ( keyword |  auto_resolve) whitespace? map;
 
 auto_resolve: '::';
 

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -471,3 +471,13 @@
   (testing "parcera should be able to parse clojurescript core"
     (let [core-content (slurp "https://raw.githubusercontent.com/clojure/clojurescript/master/src/main/clojure/cljs/core.cljc")]
       (time (is (= core-content (parcera/code (parcera/ast core-content :optimize :memory))))))))
+
+
+;; when in doubt enable the test below. I parses clojure reader test suite so, if we
+;; expect something to work it probably will be tested there.
+#_(testing "parcera should be able to parse clojurescript core"
+    (let [core-content (slurp "https://raw.githubusercontent.com/clojure/clojure/master/test/clojure/test_clojure/reader.cljc")]
+      (for [form (tree-seq seq? seq (parcera/ast core-content :optimize :memory))
+            :when (coll? form)
+            :when (contains? #{::parcera/failure} (first form))]
+        [form (meta form)])))

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -232,7 +232,11 @@
       (is (roundtrip input)))
     ;; ::/ is valid according to parcera's lexer but not for Clojure
     (let [input "::/"]
-      (is (not (valid? input))))))
+      (is (not (valid? input)))))
+  (testing "numbers"
+    (let [input "0x1f"]
+      (is (valid? input))
+      (is (roundtrip input)))))
 
 
 (deftest macros

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -236,6 +236,18 @@
   (testing "numbers"
     (let [input "0x1f"]
       (is (valid? input))
+      (is (roundtrip input)))
+    (let [input "2r101010"]
+      (is (valid? input))
+      (is (roundtrip input)))
+    (let [input "8r52"]
+      (is (valid? input))
+      (is (roundtrip input)))
+    (let [input "36r16"]
+      (is (valid? input))
+      (is (roundtrip input)))
+    (let [input "22/7"]
+      (is (valid? input))
       (is (roundtrip input)))))
 
 
@@ -459,3 +471,11 @@
   (testing "parcera should be able to parse clojurescript core"
     (let [core-content (slurp "https://raw.githubusercontent.com/clojure/clojurescript/master/src/main/clojure/cljs/core.cljc")]
       (time (is (= core-content (parcera/code (parcera/ast core-content :optimize :memory))))))))
+
+
+#_(testing "parcera should be able to parse clojurescript core"
+    (let [core-content (slurp "https://raw.githubusercontent.com/clojure/clojure/master/test/clojure/test_clojure/reader.cljc")]
+      (for [form (tree-seq seq? seq (parcera/ast core-content :optimize :memory))
+            :when (coll? form)
+            :when (contains? #{::parcera/failure} (first form))]
+        [form (meta form)])))

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -471,11 +471,3 @@
   (testing "parcera should be able to parse clojurescript core"
     (let [core-content (slurp "https://raw.githubusercontent.com/clojure/clojurescript/master/src/main/clojure/cljs/core.cljc")]
       (time (is (= core-content (parcera/code (parcera/ast core-content :optimize :memory))))))))
-
-
-#_(testing "parcera should be able to parse clojurescript core"
-    (let [core-content (slurp "https://raw.githubusercontent.com/clojure/clojure/master/test/clojure/test_clojure/reader.cljc")]
-      (for [form (tree-seq seq? seq (parcera/ast core-content :optimize :memory))
-            :when (coll? form)
-            :when (contains? #{::parcera/failure} (first form))]
-        [form (meta form)])))


### PR DESCRIPTION
- fixes #39 
- allows an optional whitespace on namespaced maps