### PR TITLE
explicitedly handle whitespace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject carocad/parcera "0.5.6"
+(defproject carocad/parcera "0.6.0"
   :description "Grammar-based Clojure parser"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -16,19 +16,22 @@ grammar Clojure;
  * https://tomassetti.me/antlr-mega-tutorial/#lexers-and-parser
 */
 
-code: form*;
+code: input*;
 
-form: whitespace | literal | collection | reader_macro;
+// useful rule to differentiate actual clojure content from anything else
+input: whitespace | form;
+
+form: literal | collection | reader_macro;
 
 // sets and namespaced map are not considerd collection from grammar perspective
 // since they start with # -> dispatch macro
 collection: list | vector | map;
 
-list: '(' form* ')';
+list: '(' input* ')';
 
-vector: '[' form* ']';
+vector: '[' input* ']';
 
-map: '{' form* '}';
+map: '{' input* '}';
 
 literal: keyword | string | number | character | symbol;
 
@@ -62,8 +65,6 @@ reader_macro: ( unquote
               | deref
               );
 
-unquote: '~' form;
-
 metadata: ((metadata_entry | deprecated_metadata_entry) whitespace?)+ ( symbol
                                                                       | collection
                                                                       | tag
@@ -82,13 +83,15 @@ metadata_entry: '^' ( map | symbol | string | keyword );
  */
 deprecated_metadata_entry: '#^' ( map | symbol | string | keyword );
 
-backtick: '`' form;
+backtick: '`' whitespace? form;
 
-quote: '\'' form;
+quote: '\'' whitespace? form;
 
-unquote_splicing: '~@' form;
+unquote: '~' whitespace? form;
 
-deref: '@' form;
+unquote_splicing: '~@' whitespace? form;
+
+deref: '@' whitespace? form;
 
 dispatch: function
           | regex
@@ -101,25 +104,25 @@ dispatch: function
           | tag
           | symbolic;
 
-function: '#(' form* ')';
+function: '#(' input* ')';
 
 regex: '#' STRING;
 
-set: '#{' form* '}';
+set: '#{' input* '}';
 
 namespaced_map: '#' ( keyword |  auto_resolve) whitespace? map;
 
 auto_resolve: '::';
 
-var_quote: '#\'' symbol;
+var_quote: '#\'' whitespace? form;
 
-discard: '#_' form;
+discard: '#_' whitespace? form;
 
 tag: '#' symbol whitespace? (literal | collection | tag);
 
-conditional: '#?(' form* ')';
+conditional: '#?(' input* ')';
 
-conditional_splicing: '#?@(' form* ')';
+conditional_splicing: '#?@(' input* ')';
 
 symbolic: '##' ('Inf' | '-Inf' | 'NaN');
 

--- a/src/clojure/parcera/core.cljc
+++ b/src/clojure/parcera/core.cljc
@@ -7,7 +7,8 @@
   #?(:cljs (:import goog.string.StringBuffer)))
 
 
-(def default-hidden {:tags     #{:form :collection :literal :keyword :reader_macro :dispatch}
+(def default-hidden {:tags     #{:form :collection :literal :keyword
+                                 :reader_macro :dispatch :input}
                      :literals #{"(" ")"
                                  "[" "]"
                                  "{" "}"
@@ -150,7 +151,7 @@
 
     :var_quote
     (do (. string-builder (append "#'"))
-        (code* (second ast) string-builder))
+        (doseq [child (rest ast)] (code* child string-builder)))
 
     :discard
     (do (. string-builder (append "#_"))

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -434,6 +434,11 @@
     ;(is (clear input))))
     (let [input "[1 2 #?@(:clj [3 4] :cljs [5 6])]"]
       (is (valid? input))
+      (is (roundtrip input))))
+
+  (testing "whitespace"
+    (let [input "(defmacro x [a] `   #'  ~  '  a)"]
+      (is (valid? input))
       (is (roundtrip input)))))
 ;(is (clear input))))))
 


### PR DESCRIPTION
- split input from form
- optional whitespace added to backtick, quote, unquote, unquote_splicing, deref, var_quote and discard
- fixes #40 