### PR TITLE
support for nested discard

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject carocad/parcera "0.6.0"
-  :description "Grammar-based Clojure parser"
+(defproject carocad/parcera "0.7.0"
+  :description "Grammar-based Clojure reader"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"
             :url  "https://github.com/carocad/parcera/blob/master/LICENSE.md"}

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -19,7 +19,7 @@ grammar Clojure;
 code: input*;
 
 // useful rule to differentiate actual clojure content from anything else
-input: whitespace | form | discard;
+input: whitespace | form ;
 
 form: literal | collection | reader_macro;
 
@@ -100,6 +100,7 @@ dispatch: function
           | conditional_splicing
           | namespaced_map
           | var_quote
+          | discard
           | tag
           | symbolic;
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -19,7 +19,7 @@ grammar Clojure;
 code: input*;
 
 // useful rule to differentiate actual clojure content from anything else
-input: whitespace | form;
+input: whitespace | form | discard;
 
 form: literal | collection | reader_macro;
 
@@ -100,7 +100,6 @@ dispatch: function
           | conditional_splicing
           | namespaced_map
           | var_quote
-          | discard
           | tag
           | symbolic;
 
@@ -116,7 +115,7 @@ auto_resolve: '::';
 
 var_quote: '#\'' whitespace? form;
 
-discard: '#_' whitespace? form;
+discard: '#_' (whitespace? discard)* whitespace? form;
 
 tag: '#' symbol whitespace? (literal | collection | tag);
 

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -298,6 +298,10 @@
     ;(is (clear input))))
     (let [input "#_macros"]
       (is (valid? input))
+      (is (roundtrip input)))
+    ;; discard statements can be "nested"
+    (let [input "#_#_:a :b"]
+      (is (valid? input))
       (is (roundtrip input))))
   ;(is (clear input)))))
 


### PR DESCRIPTION
- fixes #45 - allows nesting discard statements
- fixes #52 - from the Clojure reader "One might say the reader has syntax defined in terms of characters, and the Clojure language has syntax defined in terms of symbols, lists, vectors, maps etc. The reader is represented by the function read, which reads the next form (not character) from a stream, and returns the object represented by that form.". Therefore `parcera` is closer to a Clojure reader than to a "dump parser". For the time being I will keep it that way and work directly on the AST rather than on the sequence of characters.