### PR TITLE
edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/carocad/parcera.svg?branch=master)](https://travis-ci.com/carocad/parcera)
 [![Clojars Project](https://img.shields.io/clojars/v/carocad/parcera.svg)](https://clojars.org/carocad/parcera)
 
-Grammar-based Clojure reader.
+Grammar-based Clojure parser.
 
 Parcera can safely read any Clojure file without any code evaluation.
 
@@ -47,11 +47,7 @@ this dependency will be in the classpath to avoid collisions.
 ;; "ns"
 ```
 
-**note**: parcera is a bit permissive for symbols and keywords, you should be
- able to parse any valid Clojure file however, I cannot guarantee that an
- *invalid* symbol/keyword will yield a failure. This is because Clojure's
- reader is very stateful and embedding all those rules into the grammar
- would make it prohibitively complex. 
+If you are interested in the grammar definition check [Clojure.g4](./src/Clojure.g4).
 
 ## contributing
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject carocad/parcera "0.10.0"
-  :description "Grammar-based Clojure reader"
+(defproject carocad/parcera "0.10.2"
+  :description "Grammar-based Clojure parser"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"
             :url  "https://github.com/carocad/parcera/blob/master/LICENSE.md"}

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -63,7 +63,14 @@ reader_macro: ( unquote
               | deref
               );
 
-metadata: ((metadata_entry | deprecated_metadata_entry) whitespace?)+ form;
+metadata: ((metadata_entry | deprecated_metadata_entry) whitespace?)+
+          ( symbol
+          | collection
+          | set
+          | namespaced_map
+          | tag
+          | function
+          );
 
 metadata_entry: '^' ( map | symbol | string | keyword );
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -48,7 +48,7 @@ number: NUMBER;
 character: CHARACTER;
 
 /*
- * custom rules NOT used here:
+ * rules NOT captured in this statement:
  * - a symbol cannot start with a number "9.5hello"
  * - a symbol cannot be followed by another symbol "hello/world/" -> "hello/world" "/"
  */
@@ -63,13 +63,7 @@ reader_macro: ( unquote
               | deref
               );
 
-metadata: ((metadata_entry | deprecated_metadata_entry) whitespace?)+
-          ( symbol
-          | collection
-          | tag
-          | unquote
-          | unquote_splicing
-          );
+metadata: ((metadata_entry | deprecated_metadata_entry) whitespace?)+ form;
 
 metadata_entry: '^' ( map | symbol | string | keyword );
 
@@ -126,7 +120,11 @@ conditional: '#?' whitespace? list;
 
 conditional_splicing: '#?@' whitespace? list;
 
-symbolic: '##' ('Inf' | '-Inf' | 'NaN');
+/* This definition allows arbitrary symbolic values; following
+ * on LispReader to just read the form and throw if the symbol
+ * is not known.
+ */
+symbolic: '##' SYMBOL;
 
 // I assume symbol and list from lisp reader, but tools.reader seems to
 // indicate something else

--- a/src/clojure/parcera/antlr/java.clj
+++ b/src/clojure/parcera/antlr/java.clj
@@ -14,20 +14,17 @@
 
 ;; A custom Error Listener to avoid Antlr printing the errors on the terminal
 ;; by default. This is also useful to mimic Instaparse :total parse mechanism
-;; such that if we get an error, we can report it as the result instead
+;; such that if we get an error, we can report it as the result instead.
+;; Besides `syntaxError` all other methods are overridden only to get ambiguity
+;; reports during development. If this is somehow shown on your application
+;; please report it :)
 (defrecord AntlrFailure [reports]
   ANTLRErrorListener
-  ;; I am not sure how to use these methods. If you came here wondering why
-  ;; is this being printed, please open an issue so that we can all benefit
-  ;; from your findings ;)
   (reportAmbiguity [this parser dfa start-index stop-index exact ambig-alts configs]
-    ;; TODO
     (println "report ambiguity: " parser dfa start-index stop-index exact ambig-alts configs))
   (reportAttemptingFullContext [this parser dfa start-index stop-index conflicting-alts configs]
-    ;; TODO
     (println "report attempting full context: " parser dfa start-index stop-index conflicting-alts configs))
   (reportContextSensitivity [this parser dfa start-index stop-index prediction configs]
-    ;; TODO
     (println "report context sensitivity: " parser dfa start-index stop-index prediction configs))
   (syntaxError [this recognizer offending-symbol line char message error]
     ;; recognizer is either clojureParser or clojureLexer

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -434,6 +434,18 @@
       (is (valid? input))
       (is (roundtrip input))))
 
+  (testing "symbolic"
+    (let [input "##Inf"]
+      (is (valid? input))
+      (is (roundtrip input)))
+    (let [input "##-Inf"]
+      (is (valid? input))
+      (is (roundtrip input)))
+    ;; symbolic names are valid symbols
+    (let [input "Inf"]
+      (is (valid? input))
+      (is (roundtrip input))))
+
   (testing "EOF"
     (let [input ":hello \"  "]
       (is (not (valid? input))))))

--- a/test/parcera/test/core.cljc
+++ b/test/parcera/test/core.cljc
@@ -85,370 +85,370 @@
                (with-out-str (pprint/pprint result)))))))
 
 
-(deftest unit-tests
-  (testing "character literals"
-    (let [input "\\t"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "\\n"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "\\r"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "\\a"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "\\é"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "\\ö"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "\\ï"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "\\ϕ"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "\ua000"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "\u000a"]
-      (is (valid? input))
-      (is (roundtrip input))))
+(deftest character-literals
+  (let [input "\\t"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "\\n"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "\\r"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "\\a"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "\\é"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "\\ö"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "\\ï"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "\\ϕ"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "\ua000"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "\u000a"]
+    (is (valid? input))
+    (is (roundtrip input))))
 
-  (testing "AST metadata"
-    (let [input    ":bar"
-          ast      (parcera/ast input)
-          location (meta (second ast))]
-      (is (= (:row (::parcera/start location)) 1))
-      (is (= (:column (::parcera/start location)) 0))
-      (is (= (:row (::parcera/start location)) 1))
-      (is (= (:column (::parcera/end location))
-             (count input)))))
+(deftest AST-metadata
+  (let [input    ":bar"
+        ast      (parcera/ast input)
+        location (meta (second ast))]
+    (is (= (:row (::parcera/start location)) 1))
+    (is (= (:column (::parcera/start location)) 0))
+    (is (= (:row (::parcera/start location)) 1))
+    (is (= (:column (::parcera/end location))
+           (count input)))))
 
-  (testing "symbols"
-    (let [input "foo"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "foo-bar"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "foo->bar"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "->"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "->as"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "föl"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "Öl"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "ϕ"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "❤️"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    #_(let [input "hello/world/"]
-        (is (not (valid? input))))
-    #_(let [input ":hello/world/"]
-        (is (not (valid? input))))
-    #_(let [input "::hello/world/"]
-        (is (not (valid? input)))))
-  ;(is (clear input))))))
-
-  (testing "tag literals"
-    ;; nested tag literals
-    (let [input "#a #b 1"]
-      (is (valid? input))))
-
-  (testing "keywords"
-    ;; a keyword can be a simple number because its first character is : which is
-    ;; NOT a number ;)
-    (let [input ":1"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input ":/"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "::/"]
+(deftest symbols
+  (let [input "foo"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "foo-bar"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "foo->bar"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "->"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "->as"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "föl"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "Öl"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "ϕ"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "❤️"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  #_(let [input "hello/world/"]
       (is (not (valid? input))))
-    (let [input "::hello/world [1 a \"3\"]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "::hello"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input ":#hello"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;; this is NOT a valid literal keyword but it is "supported" by the current
-    ;; reader
-    (let [input ":http://www.department0.university0.edu/GraduateCourse52"]
-      (is (valid? input))
-      (is (roundtrip input))))
-
-  (testing "numbers"
-    (let [input "0x1f"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "2r101010"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "8r52"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "36r16"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "22/7"]
-      (is (valid? input))
-      (is (roundtrip input))))
-
-  (testing "metadata"
-    (let [input "^String [a b 2]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "^\"String\" [a b 2]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "^:string [a b 2]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "^{:a 1} [a b 2]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "^:hello ^\"World\" ^{:a 1} [a b 2]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;; DEPRECATED meta data macro style
-    (let [input "(meta #^{:a 10} #^String {})"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
-
-  (testing "discard"
-    (let [input "#_[a b 2]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "#_(a b 2)"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "#_{:a 1}"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "#_macros"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;; discard statements can be "nested"
-    (let [input "#_#_:a :b"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "#_#_ :a"]
+  #_(let [input ":hello/world/"]
+      (is (not (valid? input))))
+  #_(let [input "::hello/world/"]
       (is (not (valid? input)))))
+;(is (clear input))))))
 
-  (testing "regex"
-    (let [input "#_\"[a b 2]\""]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest tag-literals
+  ;; nested tag literals
+  (let [input "#a #b 1"]
+    (is (valid? input))))
 
-  (testing "comments"
-    (let [input "{:hello ;2}
-                   2}"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input ";[a b 2]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input ";; \"[a b 2]\""]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "2 ;[a b 2]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input " :hello ;; \"[a b 2]\""]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input " :hello #! \"[a b 2]\""]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "#! invalid { input '"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest keywords
+  ;; a keyword can be a simple number because its first character is : which is
+  ;; NOT a number ;)
+  (let [input ":1"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input ":/"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "::/"]
+    (is (not (valid? input))))
+  (let [input "::hello/world [1 a \"3\"]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "::hello"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input ":#hello"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;; this is NOT a valid literal keyword but it is "supported" by the current
+  ;; reader
+  (let [input ":http://www.department0.university0.edu/GraduateCourse52"]
+    (is (valid? input))
+    (is (roundtrip input))))
 
-  (testing "var quote"
-    (let [input "#'hello/world"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "#'/"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest numbers
+  (let [input "0x1f"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "2r101010"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "8r52"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "36r16"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "22/7"]
+    (is (valid? input))
+    (is (roundtrip input))))
 
-  (testing "tag"
-    (let [input "#hello/world [1 a \"3\"]"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "#hello/world {1 \"3\"}"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest metadata
+  (let [input "^String [a b 2]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "^\"String\" [a b 2]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "^:string [a b 2]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "^{:a 1} [a b 2]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "^:hello ^\"World\" ^{:a 1} [a b 2]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;; DEPRECATED meta data macro style
+  (let [input "(meta #^{:a 10} #^String {})"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "quote"
-    (let [input "'hello/world"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "'hello"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "'/"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
 
-  (testing "backtick"
-    (let [input "`hello/world"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "`hello"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "`/"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest discard
+  (let [input "#_[a b 2]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "#_(a b 2)"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "#_{:a 1}"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "#_macros"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;; discard statements can be "nested"
+  (let [input "#_#_:a :b"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "#_#_ :a"]
+    (is (not (valid? input)))))
 
-  (testing "unquote"
-    (let [input "~hello/world"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "~(hello 2 3)"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "~/"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest regex
+  (let [input "#_\"[a b 2]\""]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "quote splicing"
-    (let [input "~@hello/world"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "~@(hello 2 b)"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest comments
+  (let [input "{:hello ;2}
+                 2}"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input ";[a b 2]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input ";; \"[a b 2]\""]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "2 ;[a b 2]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input " :hello ;; \"[a b 2]\""]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input " :hello #! \"[a b 2]\""]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "#! invalid { input '"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "deref"
-    (let [input "@hello/world"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "@hello"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "@/"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest var-quote
+  (let [input "#'hello/world"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "#'/"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "anonymous function"
-    (let [input "#(= (str %1 %2 %&))"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest tag
+  (let [input "#hello/world [1 a \"3\"]"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "#hello/world {1 \"3\"}"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "namespaced map"
-    (let [input "#::{:a 1 b 3}"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "#::hello{:a 1 b 3}"]
-      (is (valid? input))
-      (is (roundtrip input))))
-  ;(is (clear input)))))
+(deftest quote
+  (let [input "'hello/world"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "'hello"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "'/"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "reader conditional"
-    (let [input "#?(:clj Double/NaN :cljs js/NaN :default nil)"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;(is (clear input))))
-    (let [input "[1 2 #?@(:clj [3 4] :cljs [5 6])]"]
-      (is (valid? input))
-      (is (roundtrip input))))
+(deftest backtick
+  (let [input "`hello/world"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "`hello"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "`/"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "whitespace"
-    (let [input "(defmacro x [a] `   #'  ~  '  a)"]
-      (is (valid? input))
-      (is (roundtrip input))))
+(deftest unquote-macro
+  (let [input "~hello/world"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "~(hello 2 3)"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "~/"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "eval"
-    (let [input "#=  (inc 1)"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "#=inc"]
-      (is (valid? input))
-      (is (roundtrip input))))
+(deftest quote-splicing
+  (let [input "~@hello/world"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "~@(hello 2 b)"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "symbolic"
-    (let [input "##Inf"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    (let [input "##-Inf"]
-      (is (valid? input))
-      (is (roundtrip input)))
-    ;; symbolic names are valid symbols
-    (let [input "Inf"]
-      (is (valid? input))
-      (is (roundtrip input))))
+(deftest deref-macro
+  (let [input "@hello/world"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "@hello"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "@/"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
 
-  (testing "EOF"
-    (let [input ":hello \"  "]
-      (is (not (valid? input))))))
+(deftest anonymous-function
+  (let [input "#(= (str %1 %2 %&))"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
+
+(deftest namespaced-map
+  (let [input "#::{:a 1 b 3}"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "#::hello{:a 1 b 3}"]
+    (is (valid? input))
+    (is (roundtrip input))))
+;(is (clear input)))))
+
+(deftest reader-conditional-macro
+  (let [input "#?(:clj Double/NaN :cljs js/NaN :default nil)"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;(is (clear input))))
+  (let [input "[1 2 #?@(:clj [3 4] :cljs [5 6])]"]
+    (is (valid? input))
+    (is (roundtrip input))))
+
+(deftest whitespace
+  (let [input "(defmacro x [a] `   #'  ~  '  a)"]
+    (is (valid? input))
+    (is (roundtrip input))))
+
+(deftest eval-macro
+  (let [input "#=  (inc 1)"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "#=inc"]
+    (is (valid? input))
+    (is (roundtrip input))))
+
+(deftest symbolic
+  (let [input "##Inf"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "##-Inf"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  ;; symbolic names are valid symbols
+  (let [input "Inf"]
+    (is (valid? input))
+    (is (roundtrip input))))
+
+(deftest EOF
+  (let [input ":hello \"  "]
+    (is (not (valid? input)))))
 ;(is (clear input))))))
 
 


### PR DESCRIPTION
- fixes #62 - allow metadata on set, namespaced_map and functions.
- fixes #63 - allow symbolic values as symbols. This drops the previous (made up) restriction of enum like values. Clojure's LispReader throws a runtime exception if the symbolic value is unknown so it seems fit to just parse it and leave it to the upper layer to handle it.