### PR TITLE
fix: comment and discard are treated as whitespace in most macros

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject carocad/parcera "0.11.1"
+(defproject carocad/parcera "0.11.2"
   :description "Grammar-based Clojure(script) parser"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -63,7 +63,7 @@ reader_macro: ( unquote
               | deref
               );
 
-metadata: ((metadata_entry | deprecated_metadata_entry) ignore*)+
+metadata: (metadata_entry | deprecated_metadata_entry)+
           ( symbol
           | collection
           | set
@@ -74,7 +74,7 @@ metadata: ((metadata_entry | deprecated_metadata_entry) ignore*)+
           | unquote_splicing
           );
 
-metadata_entry: '^' ( map | symbol | string | keyword | macro_keyword );
+metadata_entry: '^' ignore* ( map | symbol | string | keyword | macro_keyword ) ignore*;
 
 /**
  * According to https://github.com/clojure/clojure-site/blob/7493bdb10222719923519bfd6d2699a26677ee82/content/guides/weird_characters.adoc#-and----metadata
@@ -83,7 +83,7 @@ metadata_entry: '^' ( map | symbol | string | keyword | macro_keyword );
  * In order to support roundtrip of parser rules it is required to exactly identify the
  * character used which would not be possible with something like '#'? '^'
  */
-deprecated_metadata_entry: '#^' ( map | symbol | string | keyword | macro_keyword );
+deprecated_metadata_entry: '#^' ignore* ( map | symbol | string | keyword | macro_keyword ) ignore*;
 
 backtick: '`' ignore* form;
 
@@ -133,7 +133,7 @@ conditional_splicing: '#?@' ignore* list;
  * on LispReader to just read the form and throw if the symbol
  * is not known.
  */
-symbolic: '##' SYMBOL;
+symbolic: '##' ignore* SYMBOL;
 
 // I assume symbol and list from lisp reader, but tools.reader seems to
 // indicate something else

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -63,7 +63,7 @@ reader_macro: ( unquote
               | deref
               );
 
-metadata: (metadata_entry | deprecated_metadata_entry)+
+metadata: ((metadata_entry | deprecated_metadata_entry) ignore*)+
           ( symbol
           | collection
           | set
@@ -74,7 +74,7 @@ metadata: (metadata_entry | deprecated_metadata_entry)+
           | unquote_splicing
           );
 
-metadata_entry: '^' ignore* ( map | symbol | string | keyword | macro_keyword ) ignore*;
+metadata_entry: '^' ignore* ( map | symbol | string | keyword | macro_keyword );
 
 /**
  * According to https://github.com/clojure/clojure-site/blob/7493bdb10222719923519bfd6d2699a26677ee82/content/guides/weird_characters.adoc#-and----metadata
@@ -83,7 +83,7 @@ metadata_entry: '^' ignore* ( map | symbol | string | keyword | macro_keyword ) 
  * In order to support roundtrip of parser rules it is required to exactly identify the
  * character used which would not be possible with something like '#'? '^'
  */
-deprecated_metadata_entry: '#^' ignore* ( map | symbol | string | keyword | macro_keyword ) ignore*;
+deprecated_metadata_entry: '#^' ignore* ( map | symbol | string | keyword | macro_keyword );
 
 backtick: '`' ignore* form;
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -19,7 +19,9 @@ grammar Clojure;
 code: input* EOF;
 
 // useful rule to differentiate actual clojure content from anything else
-input: whitespace | comment | discard | form ;
+input: ignore | form ;
+
+ignore: whitespace | comment | discard;
 
 form: literal | collection | reader_macro;
 
@@ -61,7 +63,7 @@ reader_macro: ( unquote
               | deref
               );
 
-metadata: ((metadata_entry | deprecated_metadata_entry) whitespace?)+
+metadata: ((metadata_entry | deprecated_metadata_entry) ignore*)+
           ( symbol
           | collection
           | set
@@ -83,15 +85,15 @@ metadata_entry: '^' ( map | symbol | string | keyword | macro_keyword );
  */
 deprecated_metadata_entry: '#^' ( map | symbol | string | keyword | macro_keyword );
 
-backtick: '`' whitespace? form;
+backtick: '`' ignore* form;
 
-quote: '\'' whitespace? form;
+quote: '\'' ignore* form;
 
-unquote: '~' whitespace? form;
+unquote: '~' ignore* form;
 
-unquote_splicing: '~@' whitespace? form;
+unquote_splicing: '~@' ignore* form;
 
-deref: '@' whitespace? form;
+deref: '@' ignore* form;
 
 dispatch: ( fn
           | regex
@@ -112,20 +114,20 @@ regex: '#' STRING;
 set: '#{' input* '}'; // no whitespace allowed
 
 namespaced_map: '#' (keyword | macro_keyword | auto_resolve)
-                    whitespace?
+                    ignore*
                     map;
 
 auto_resolve: '::';
 
-var_quote: '#\'' whitespace? form;
+var_quote: '#\'' ignore* form;
 
-discard: '#_' (whitespace? discard)? whitespace? form;
+discard: '#_' ignore* form;
 
-tag: '#' symbol whitespace? (literal | collection | tag);
+tag: '#' symbol ignore* (literal | collection | tag);
 
-conditional: '#?' whitespace? list;
+conditional: '#?' ignore* list;
 
-conditional_splicing: '#?@' whitespace? list;
+conditional_splicing: '#?@' ignore* list;
 
 /* This definition allows arbitrary symbolic values; following
  * on LispReader to just read the form and throw if the symbol
@@ -135,7 +137,7 @@ symbolic: '##' SYMBOL;
 
 // I assume symbol and list from lisp reader, but tools.reader seems to
 // indicate something else
-eval: '#=' whitespace? (symbol | list);
+eval: '#=' ignore* (symbol | list);
 
 whitespace: WHITESPACE;
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -125,9 +125,9 @@ discard: '#_' ignore* form;
 
 tag: '#' symbol ignore* (literal | collection | tag);
 
-conditional: '#?' ignore* list;
+conditional: '#?' whitespace* list;
 
-conditional_splicing: '#?@' ignore* list;
+conditional_splicing: '#?@' whitespace* list;
 
 /* This definition allows arbitrary symbolic values; following
  * on LispReader to just read the form and throw if the symbol

--- a/src/clojure/parcera/core.cljc
+++ b/src/clojure/parcera/core.cljc
@@ -112,7 +112,8 @@
 
     :symbolic
     (do (. string-builder (append "##"))
-        (. string-builder (append (second ast))))
+        (doseq [child (rest (butlast ast))] (code* child string-builder))
+        (. string-builder (append (last ast))))
 
     :regex
     (do (. string-builder (append "#"))

--- a/src/clojure/parcera/core.cljc
+++ b/src/clojure/parcera/core.cljc
@@ -123,18 +123,15 @@
     (. string-builder (append "::"))
 
     :metadata
-    (do (doseq [child (rest (butlast ast))] (code* child string-builder))
-        (code* (last ast) string-builder))
+    (do (doseq [child (rest ast)] (code* child string-builder)))
 
     :metadata_entry
-    (doseq [child (rest ast)]
-      (. string-builder (append "^"))
-      (code* child string-builder))
+    (do (. string-builder (append "^"))
+        (doseq [child (rest ast)] (code* child string-builder)))
 
     :deprecated_metadata_entry
-    (doseq [child (rest ast)]
-      (. string-builder (append "#^"))
-      (code* child string-builder))
+    (do (. string-builder (append "#^"))
+        (doseq [child (rest ast)] (code* child string-builder)))
 
     :quote
     (do (. string-builder (append "'"))

--- a/src/clojure/parcera/core.cljc
+++ b/src/clojure/parcera/core.cljc
@@ -5,7 +5,8 @@
 
 
 (def default-hidden {:tags     #{:form :collection :literal
-                                 :reader_macro :dispatch :input}
+                                 :reader_macro :dispatch :input
+                                 :ignore}
                      :literals #{"(" ")"
                                  "[" "]"
                                  "{" "}"

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -235,27 +235,30 @@
   (let [input "^String [a b 2]"]
     (is (valid? input))
     (is (roundtrip input)))
-  ;(is (clear input))))
   (let [input "^\"String\" [a b 2]"]
     (is (valid? input))
     (is (roundtrip input)))
-  ;(is (clear input))))
   (let [input "^:string [a b 2]"]
     (is (valid? input))
     (is (roundtrip input)))
-  ;(is (clear input))))
   (let [input "^{:a 1} [a b 2]"]
     (is (valid? input))
     (is (roundtrip input)))
-  ;(is (clear input))))
   (let [input "^:hello ^\"World\" ^{:a 1} [a b 2]"]
     (is (valid? input))
     (is (roundtrip input)))
   ;; DEPRECATED meta data macro style
   (let [input "(meta #^{:a 10} #^String {})"]
     (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "^
+        #_ :a
+        {:a true}
+        ;; hello
+        #^ #_ hello :world
+        [:a]"]
+    (is (valid? input))
     (is (roundtrip input))))
-;(is (clear input)))))
 
 
 (deftest discard
@@ -324,7 +327,9 @@
   (let [input "#! invalid { input '"]
     (is (valid? input))
     (is (roundtrip input)))
-  (let [input "^{:a true} ;; hello\n #_ :hello [:a]"]
+  (let [input "^{:a true} ;; hello
+                          #_ :hello
+                          [:a]"]
     (is (valid? input))
     (is (roundtrip input))))
 
@@ -481,7 +486,13 @@
   ;; symbolic names are valid symbols
   (let [input "Inf"]
     (is (valid? input))
-    (is (roundtrip input))))
+    (is (roundtrip input)))
+  (let [input "## #_ hello
+                  ;; world
+                  Inf"]
+    (is (valid? input))
+    (is (= input (parcera/code (parcera/ast input))))))
+
 
 (deftest EOF
   (let [input ":hello \"  "]

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -282,7 +282,7 @@
     (valid? input)
     (roundtrip input))
   (let [input "#_#_ :a"]
-    (is (not (valid? input))))
+    (is (parcera/failure? (parcera/ast input))))
   (let [input "#_
                   ;; hello
                   #_
@@ -496,7 +496,7 @@
 
 (deftest EOF
   (let [input ":hello \"  "]
-    (is (not (valid? input)))))
+    (is (parcera/failure? (parcera/ast input)))))
 ;(is (clear input))))))
 
 

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -32,15 +32,15 @@
          (<= (:column end) (:column (last ends))))))
 
 
-(defn- roundtrip
+(defmacro roundtrip
   "checks parcera can parse and write back the exact same input code"
   [input]
-  (= input (parcera/code (parcera/ast input))))
+  `(is (= ~input (parcera/code (parcera/ast ~input)))))
 
 
-(defn- valid?
+(defmacro valid?
   [input]
-  (not (parcera/failure? (parcera/ast input))))
+  `(is (not (parcera/failure? (parcera/ast ~input)))))
 
 
 (def validity
@@ -87,42 +87,42 @@
 
 (deftest character-literals
   (let [input "\\t"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "\\n"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "\\r"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "\\a"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "\\é"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "\\ö"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "\\ï"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "\\ϕ"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "\ua000"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "\u000a"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest AST-metadata
@@ -138,40 +138,40 @@
 
 (deftest symbols
   (let [input "foo"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "foo-bar"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "foo->bar"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "->"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "->as"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "föl"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "Öl"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "ϕ"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "❤️"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   #_(let [input "hello/world/"]
       (is (not (valid? input))))
   #_(let [input ":hello/world/"]
@@ -183,104 +183,104 @@
 (deftest tag-literals
   ;; nested tag literals
   (let [input "#a #b 1"]
-    (is (valid? input))))
+    (valid? input)))
 
 
 (deftest keywords
   ;; a keyword can be a simple number because its first character is : which is
   ;; NOT a number ;)
   (let [input ":1"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input ":/"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "::/"]
-    (is (not (valid? input))))
+    (is (parcera/failure? (parcera/ast input))))
   (let [input "::hello/world [1 a \"3\"]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "::hello"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input ":#hello"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;; this is NOT a valid literal keyword but it is "supported" by the current
   ;; reader
   (let [input ":http://www.department0.university0.edu/GraduateCourse52"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest numbers
   (let [input "0x1f"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "2r101010"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "8r52"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "36r16"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "22/7"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest metadata
   (let [input "^String [a b 2]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "^\"String\" [a b 2]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "^:string [a b 2]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "^{:a 1} [a b 2]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "^:hello ^\"World\" ^{:a 1} [a b 2]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;; DEPRECATED meta data macro style
   (let [input "(meta #^{:a 10} #^String {})"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "^
         #_ :a
         {:a true}
         ;; hello
         #^ #_ hello :world
         [:a]"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest discard
   (let [input "#_[a b 2]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "#_(a b 2)"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "#_{:a 1}"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "#_macros"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;; discard statements can be "nested"
   (let [input "#_#_:a :b"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "#_#_ :a"]
     (is (not (valid? input))))
   (let [input "#_
@@ -291,206 +291,206 @@
                   true
               ;; hey
               \"jo\""]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest regex
   (let [input "#_\"[a b 2]\""]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest comments
   (let [input "{:hello ;2}
                  2}"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input ";[a b 2]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input ";; \"[a b 2]\""]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "2 ;[a b 2]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input " :hello ;; \"[a b 2]\""]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input " :hello #! \"[a b 2]\""]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "#! invalid { input '"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "^{:a true} ;; hello
                           #_ :hello
                           [:a]"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest var-quote
   (let [input "#'hello/world"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "#'/"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "#' #_ :hello str"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest tag
   (let [input "#hello/world [1 a \"3\"]"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "#hello/world {1 \"3\"}"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest quote
   (let [input "'hello/world"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "'hello"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "'/"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "' #_ :hello (str \"world\")"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest backtick
   (let [input "`hello/world"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "`hello"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "`/"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "` #_ :hello (str \"world\")"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest unquote-macro
   (let [input "~hello/world"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "~(hello 2 3)"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "~/"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest quote-splicing
   (let [input "~@hello/world"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "~@(hello 2 b)"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest deref-macro
   (let [input "@hello/world"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "@hello"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "@/"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest anonymous-function
   (let [input "#(= (str %1 %2 %&))"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest namespaced-map
   (let [input "#::{:a 1 b 3}"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "#::hello{:a 1 b 3}"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "::platform #_ :world #_rofl {:hello true}"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest reader-conditional-macro
   (let [input "#?(:clj Double/NaN :cljs js/NaN :default nil)"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;(is (clear input))))
   (let [input "[1 2 #?@(:clj [3 4] :cljs [5 6])]"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest whitespace
   (let [input "(defmacro x [a] `   #'  ~  '  a)"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest eval-macro
   (let [input "#=  (inc 1)"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "#=inc"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "#= #_true #_ :hello (println 3)"]
-    (is (valid? input))
-    (is (roundtrip input))))
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest symbolic
   (let [input "##Inf"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "##-Inf"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   ;; symbolic names are valid symbols
   (let [input "Inf"]
-    (is (valid? input))
-    (is (roundtrip input)))
+    (valid? input)
+    (roundtrip input))
   (let [input "## #_ hello
                   ;; world
                   Inf"]
-    (is (valid? input))
+    (valid? input)
     (is (= input (parcera/code (parcera/ast input))))))
 
 
@@ -504,19 +504,19 @@
 
   (testing "parcera should be able to parse itself"
     (let [input (slurp "./src/clojure/parcera/core.cljc")]
-      (is (valid? input))
-      (is (roundtrip input))))
+      (valid? input)
+      (roundtrip input)))
 
   (testing "parcera should be able to parse its own test suite"
     (let [input (slurp "./test/parcera/test_cases.cljc")]
-      (is (valid? input))
-      (is (roundtrip input)))
+      (valid? input)
+      (roundtrip input))
     (let [input (slurp "./test/parcera/benchmark.clj")]
-      (is (valid? input))
-      (is (roundtrip input)))
+      (valid? input)
+      (roundtrip input))
     (let [input (slurp "./test/parcera/slurp.cljc")]
-      (is (valid? input))
-      (is (roundtrip input)))))
+      (valid? input)
+      (roundtrip input))))
 
 (defonce clojure (slurp "https://raw.githubusercontent.com/clojure/clojure/master/src/clj/clojure/core.clj"))
 (defonce clojure$script (slurp "https://raw.githubusercontent.com/clojure/clojurescript/master/src/main/clojure/cljs/core.cljc"))

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -279,7 +279,17 @@
     (is (valid? input))
     (is (roundtrip input)))
   (let [input "#_#_ :a"]
-    (is (not (valid? input)))))
+    (is (not (valid? input))))
+  (let [input "#_
+                  ;; hello
+                  #_
+                      ;; world
+                      :hello
+                  true
+              ;; hey
+              \"jo\""]
+    (is (valid? input))
+    (is (roundtrip input))))
 
 
 (deftest regex
@@ -313,6 +323,9 @@
     (is (roundtrip input)))
   (let [input "#! invalid { input '"]
     (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "^{:a true} ;; hello\n #_ :hello [:a]"]
+    (is (valid? input))
     (is (roundtrip input))))
 
 
@@ -322,6 +335,9 @@
     (is (roundtrip input)))
   ;(is (clear input))))
   (let [input "#'/"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "#' #_ :hello str"]
     (is (valid? input))
     (is (roundtrip input))))
 
@@ -347,6 +363,9 @@
   ;(is (clear input))))
   (let [input "'/"]
     (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "' #_ :hello (str \"world\")"]
+    (is (valid? input))
     (is (roundtrip input))))
 
 
@@ -360,6 +379,9 @@
     (is (roundtrip input)))
   ;(is (clear input))))
   (let [input "`/"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "` #_ :hello (str \"world\")"]
     (is (valid? input))
     (is (roundtrip input))))
 
@@ -415,6 +437,9 @@
   ;(is (clear input))))
   (let [input "#::hello{:a 1 b 3}"]
     (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "::platform #_ :world #_rofl {:hello true}"]
+    (is (valid? input))
     (is (roundtrip input))))
 
 
@@ -439,6 +464,9 @@
     (is (valid? input))
     (is (roundtrip input)))
   (let [input "#=inc"]
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "#= #_true #_ :hello (println 3)"]
     (is (valid? input))
     (is (roundtrip input))))
 

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -450,13 +450,21 @@
 
 (deftest reader-conditional-macro
   (let [input "#?(:clj Double/NaN :cljs js/NaN :default nil)"]
-    (valid? input)
-    (roundtrip input))
-  ;(is (clear input))))
+    (is (valid? input))
+    (is (roundtrip input)))
   (let [input "[1 2 #?@(:clj [3 4] :cljs [5 6])]"]
-    (valid? input)
-    (roundtrip input)))
-
+    (is (valid? input))
+    (is (roundtrip input)))
+  (let [input "#? ;; hello
+    (
+     :clj  (println \"hello\")
+     :cljs (println \"world\"))"]
+    (is (parcera/failure? (parcera/ast input))))
+  (let [input "#?   (
+     :clj  (println \"hello\")
+     :cljs (println \"world\"))"]
+    (is (valid? input))
+    (is (roundtrip input))))
 
 (deftest whitespace
   (let [input "(defmacro x [a] `   #'  ~  '  a)"]


### PR DESCRIPTION
fixes #74 