### PR TITLE
Octal fix

### DIFF
--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -191,7 +191,7 @@ fragment UNICODE: 'u' [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F];
 // octal character must be between 0 and 377
 // https://github.com/clojure/clojure/blob/06097b1369c502090be6489be27cc280633cb1bd/src/jvm/clojure/lang/LispReader.java#L604
 // https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html
-fragment OCTAL: 'o' ([0-7]) | ([0-7] [0-7]) | ([0-3] [0-7] [0-7]);
+fragment OCTAL: 'o' ([0-7] | ([0-7] [0-7]) | ([0-3] [0-7] [0-7]));
 
 fragment KEYWORD_BODY: KEYWORD_HEAD | [:/];
 

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -126,7 +126,7 @@
   (let [input "\\o123"]
     (valid? input)
     (roundtrip input)
-    (is (= (parcera/ast input) [:code [:character "\o123"]])))
+    (is (= (parcera/ast input) [:code [:character input]])))
   (let [input "\\o0"]
     (valid? input)
     (roundtrip input)))

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -125,7 +125,8 @@
     (roundtrip input))
   (let [input "\\o123"]
     (valid? input)
-    (roundtrip input))
+    (roundtrip input)
+    (is (= (parcera/ast input) [:code [:character "\o123"]])))
   (let [input "\\o0"]
     (valid? input)
     (roundtrip input)))


### PR DESCRIPTION
the wrong parenthesis made multicharacter octals to not match when they could.