### PR TITLE
modify lexer rules for proper matching

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject carocad/parcera "0.11.4"
+(defproject carocad/parcera "0.11.5"
   :description "Grammar-based Clojure(script) parser"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -43,7 +43,7 @@ macro_keyword: MACRO_KEYWORD;
 
 string: STRING;
 
-number: NUMBER;
+number: (OCTAL | HEXADECIMAL | RADIX | RATIO | LONG | DOUBLE);
 
 character: CHARACTER;
 
@@ -148,7 +148,22 @@ whitespace: WHITESPACE;
 
 comment: COMMENT;
 
-NUMBER: SIGN? DIGIT+ (DOUBLE_SUFFIX | LONG_SUFFIX | RATIO_SUFFIX);
+// check LispReader for the patterns used to match numbers
+OCTAL: SIGN? '0' [0-7]+;
+
+HEXADECIMAL: SIGN? '0' [xX][0-9A-Fa-f]+;
+
+RADIX: SIGN? ([2-9] | ([1-2][0-9]) | ('3'[0-6]))
+             [rR]
+             [0-9a-zA-Z]+;
+
+RATIO: SIGN? DIGIT+ '/' DIGIT+;
+
+LONG: SIGN? DECIMAL 'N'?;
+
+DOUBLE: SIGN? DECIMAL ('.' DIGIT*)? ([eE]SIGN?DIGIT+)? 'M'?;
+
+fragment DECIMAL: ('0' | ([1-9] DIGIT*));
 
 STRING: '"' ~["\\]* ('\\' . ~["\\]*)* '"';
 
@@ -156,7 +171,7 @@ WHITESPACE: [\r\n\t\f, ]+;
 
 COMMENT: (';' | '#!') ~[\r\n]*;
 
-CHARACTER: '\\' (NAMED_CHAR | UNICODE | OCTAL | UNICODE_CHAR);
+CHARACTER: '\\' (NAMED_CHAR | UNICODE | OCTAL_CHAR | UNICODE_CHAR);
 
 // note: ::/ is NOT a valid macro keyword, unlike :/
 MACRO_KEYWORD: '::' KEYWORD_HEAD KEYWORD_BODY*;
@@ -203,7 +218,7 @@ fragment UNICODE: 'u' [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F];
 // octal character must be between 0 and 377
 // https://github.com/clojure/clojure/blob/06097b1369c502090be6489be27cc280633cb1bd/src/jvm/clojure/lang/LispReader.java#L604
 // https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html
-fragment OCTAL: 'o' ([0-7] | ([0-7] [0-7]) | ([0-3] [0-7] [0-7]));
+fragment OCTAL_CHAR: 'o' ([0-7] | ([0-7] [0-7]) | ([0-3] [0-7] [0-7]));
 
 fragment KEYWORD_BODY: KEYWORD_HEAD | [:/];
 
@@ -217,16 +232,6 @@ fragment SYMBOL_HEAD: ALLOWED_NAME_CHARACTER | [#'/] | SIGN;
 // these is the set of characters that are allowed by all symbols and keywords
 // however, this is more strict that necessary so that we can re-use it for both
 fragment ALLOWED_NAME_CHARACTER: ~[\r\n\t\f ()[\]{}"@~^;`\\,:#'/0-9+-];
-
-fragment DOUBLE_SUFFIX: ((('.' DIGIT*)? ([eE][-+]?DIGIT+)?) 'M'?);
-
-// check LispReader for the pattern used by Clojure
-fragment LONG_SUFFIX: ( [xX][0-9A-Fa-f]+
-                      | [0-7]+
-                      | [rR][0-9a-zA-Z]+
-                      )? 'N'?;
-
-fragment RATIO_SUFFIX: '/' DIGIT+;
 
 fragment SIGN: [+-];
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -149,9 +149,9 @@ whitespace: WHITESPACE;
 comment: COMMENT;
 
 // check LispReader for the patterns used to match numbers
-OCTAL: SIGN? '0' [0-7]+ BIG_INT?;
+OCTAL: SIGN? ZERO [0-7]+ BIG_INT?;
 
-HEXADECIMAL: SIGN? '0' [xX][0-9A-Fa-f]+ BIG_INT?;
+HEXADECIMAL: SIGN? ZERO [xX][0-9A-Fa-f]+ BIG_INT?;
 
 // radix cannot be read as a big int? 🤔 is this a bug in LispReader?
 RADIX: SIGN? ([2-9] | ([1-2][0-9]) | ('3'[0-6]))
@@ -166,7 +166,9 @@ fragment BIG_INT: 'N';
 
 DOUBLE: SIGN? DECIMAL ('.' DIGIT*)? ([eE]SIGN?DIGIT+)? 'M'?;
 
-fragment DECIMAL: ('0' | ([1-9] DIGIT*));
+fragment DECIMAL: (ZERO | ([1-9] DIGIT*));
+
+fragment ZERO: '0';
 
 STRING: '"' ~["\\]* ('\\' . ~["\\]*)* '"';
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -223,7 +223,7 @@ SYMBOL: '/' // edge case; / is also the namespace separator
 // of two valid tokens. Examples:
 // +9hello -> [:number +9] [:symbol hello]
 // \o423 -> [:character \o43] [:number 2]
-SENTINEL: (ALLOWED_NAME_CHARACTER | DIGIT | SIGN | [/\\])+;
+SENTINEL: ESCAPE? (ALLOWED_NAME_CHARACTER | DIGIT | SIGN | [/])+;
 
 fragment KEYWORD_BODY: KEYWORD_HEAD | [:/];
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -149,17 +149,20 @@ whitespace: WHITESPACE;
 comment: COMMENT;
 
 // check LispReader for the patterns used to match numbers
-OCTAL: SIGN? '0' [0-7]+;
+OCTAL: SIGN? '0' [0-7]+ BIG_INT?;
 
-HEXADECIMAL: SIGN? '0' [xX][0-9A-Fa-f]+;
+HEXADECIMAL: SIGN? '0' [xX][0-9A-Fa-f]+ BIG_INT?;
 
+// radix cannot be read as a big int? 🤔 is this a bug in LispReader?
 RADIX: SIGN? ([2-9] | ([1-2][0-9]) | ('3'[0-6]))
              [rR]
              [0-9a-zA-Z]+;
 
 RATIO: SIGN? DIGIT+ '/' DIGIT+;
 
-LONG: SIGN? DECIMAL 'N'?;
+LONG: SIGN? DECIMAL BIG_INT?;
+
+fragment BIG_INT: 'N';
 
 DOUBLE: SIGN? DECIMAL ('.' DIGIT*)? ([eE]SIGN?DIGIT+)? 'M'?;
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -167,7 +167,8 @@ fragment DECIMAL: ('0' | ([1-9] DIGIT*));
 
 STRING: '"' ~["\\]* ('\\' . ~["\\]*)* '"';
 
-WHITESPACE: [\r\n\t\f, ]+;
+// any unicode whitespace "character"
+WHITESPACE: [\p{White_Space},]+;
 
 COMMENT: (';' | '#!') ~[\r\n]*;
 
@@ -235,7 +236,7 @@ fragment SYMBOL_HEAD: ALLOWED_NAME_CHARACTER | [#'/] | SIGN;
 
 // these is the set of characters that are allowed by all symbols and keywords
 // however, this is more strict that necessary so that we can re-use it for both
-fragment ALLOWED_NAME_CHARACTER: ~[\r\n\t\f ()[\]{}"@~^;`\\,:#'/0-9+-];
+fragment ALLOWED_NAME_CHARACTER: ~[\p{White_Space},()[\]{}"@~^;`\\:#'/0-9+-];
 
 fragment SIGN: [+-];
 

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -185,7 +185,14 @@ SYMBOL: '/' // edge case; / is also the namespace separator
         // a symbol that starts with +- cannot be followed by a number
         | ([+-] SYMBOL_HEAD SYMBOL_BODY*)
         // a symbol that doesnt start with +- can be followed by a number like 't2#'
-        | (ALLOWED_NAME_CHARACTER (SYMBOL_HEAD | [0-9]) SYMBOL_BODY*);
+        | (ALLOWED_NAME_CHARACTER (SYMBOL_HEAD | DIGIT) SYMBOL_BODY*);
+
+// https://stackoverflow.com/a/15503680
+// used to avoid the parser matching a single invalid token as the composition
+// of two valid tokens. Examples:
+// +9hello -> [:number +9] [:symbol hello]
+// \o423 -> [:character \o43] [:number 2]
+SENTINEL: (ALLOWED_NAME_CHARACTER | DIGIT | [+-] | [/\\])+;
 
 fragment UNICODE_CHAR: ~[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF];
 
@@ -200,12 +207,12 @@ fragment OCTAL: 'o' ([0-7] | ([0-7] [0-7]) | ([0-3] [0-7] [0-7]));
 
 fragment KEYWORD_BODY: KEYWORD_HEAD | [:/];
 
-fragment KEYWORD_HEAD: ALLOWED_NAME_CHARACTER | [#'0-9+-];
+fragment KEYWORD_HEAD: ALLOWED_NAME_CHARACTER | DIGIT | [#'+-];
 
 // symbols can contain : # ' as part of their names
-fragment SYMBOL_BODY: SYMBOL_HEAD | [:#'0-9];
+fragment SYMBOL_BODY: SYMBOL_HEAD | DIGIT | ':';
 
-fragment SYMBOL_HEAD: ALLOWED_NAME_CHARACTER | [#'/+-];
+fragment SYMBOL_HEAD: ALLOWED_NAME_CHARACTER | [#'+-/];
 
 // these is the set of characters that are allowed by all symbols and keywords
 // however, this is more strict that necessary so that we can re-use it for both

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -148,7 +148,7 @@ whitespace: WHITESPACE;
 
 comment: COMMENT;
 
-NUMBER: [+-]? DIGIT+ (DOUBLE_SUFFIX | LONG_SUFFIX | RATIO_SUFFIX);
+NUMBER: SIGN? DIGIT+ (DOUBLE_SUFFIX | LONG_SUFFIX | RATIO_SUFFIX);
 
 STRING: '"' ~["\\]* ('\\' . ~["\\]*)* '"';
 
@@ -181,9 +181,9 @@ KEYWORD: ':' ((KEYWORD_HEAD KEYWORD_BODY*) | '/');
  */
 SYMBOL: '/' // edge case; / is also the namespace separator
         // a single character like + - / etc
-        | (ALLOWED_NAME_CHARACTER | [+-])
+        | (ALLOWED_NAME_CHARACTER | SIGN)
         // a symbol that starts with +- cannot be followed by a number
-        | ([+-] SYMBOL_HEAD SYMBOL_BODY*)
+        | (SIGN SYMBOL_HEAD SYMBOL_BODY*)
         // a symbol that doesnt start with +- can be followed by a number like 't2#'
         | (ALLOWED_NAME_CHARACTER (SYMBOL_HEAD | DIGIT) SYMBOL_BODY*);
 
@@ -192,7 +192,7 @@ SYMBOL: '/' // edge case; / is also the namespace separator
 // of two valid tokens. Examples:
 // +9hello -> [:number +9] [:symbol hello]
 // \o423 -> [:character \o43] [:number 2]
-SENTINEL: (ALLOWED_NAME_CHARACTER | DIGIT | [+-] | [/\\])+;
+SENTINEL: (ALLOWED_NAME_CHARACTER | DIGIT | SIGN | [/\\])+;
 
 fragment UNICODE_CHAR: ~[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF];
 
@@ -207,12 +207,12 @@ fragment OCTAL: 'o' ([0-7] | ([0-7] [0-7]) | ([0-3] [0-7] [0-7]));
 
 fragment KEYWORD_BODY: KEYWORD_HEAD | [:/];
 
-fragment KEYWORD_HEAD: ALLOWED_NAME_CHARACTER | DIGIT | [#'+-];
+fragment KEYWORD_HEAD: ALLOWED_NAME_CHARACTER | DIGIT | [#'] | SIGN;
 
 // symbols can contain : # ' as part of their names
 fragment SYMBOL_BODY: SYMBOL_HEAD | DIGIT | ':';
 
-fragment SYMBOL_HEAD: ALLOWED_NAME_CHARACTER | [#'+-/];
+fragment SYMBOL_HEAD: ALLOWED_NAME_CHARACTER | [#'/] | SIGN;
 
 // these is the set of characters that are allowed by all symbols and keywords
 // however, this is more strict that necessary so that we can re-use it for both
@@ -227,5 +227,7 @@ fragment LONG_SUFFIX: ( [xX][0-9A-Fa-f]+
                       )? 'N'?;
 
 fragment RATIO_SUFFIX: '/' DIGIT+;
+
+fragment SIGN: [+-];
 
 fragment DIGIT: [0-9];

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -268,7 +268,11 @@
       (roundtrip input)))
   (let [inputs ["08" "0x1G"]]
     (doseq [input inputs]
-      (is (parcera/failure? (parcera/ast input))))))
+      (is (parcera/failure? (parcera/ast input)))))
+  (let [input "0007000321110000334004002007N"]
+    (is (= (parcera/ast input) [:code [:number input]])))
+  (let [input "0x07000321110000334004002007N"]
+    (is (= (parcera/ast input) [:code [:number input]]))))
 
 
 (deftest metadata

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -210,7 +210,6 @@
   (let [input "#a #b 1"]
     (valid? input)))
 
-
 (deftest keywords
   ;; a keyword can be a simple number because its first character is : which is
   ;; NOT a number ;)
@@ -253,7 +252,14 @@
     (roundtrip input))
   (let [input "22/7"]
     (valid? input)
-    (roundtrip input)))
+    (roundtrip input))
+  (let [inputs ["0" "0.0" "0M" "0N" "0.0e8M" "017" "07" "0x1A" "2r101010" "8r52" "36r16"]]
+    (doseq [input inputs]
+      (valid? input)
+      (roundtrip input)))
+  (let [inputs ["08" "0x1G"]]
+    (doseq [input inputs]
+      (is (parcera/failure? (parcera/ast input))))))
 
 
 (deftest metadata

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -129,12 +129,11 @@
     (is (= (parcera/ast input) [:code [:character input]])))
   (let [input "\\o0"]
     (valid? input)
-    (roundtrip input)))
-; todo: the tests below should fail but currently dont
-;(let [input "\\o432"]
-;  (is (parcera/failure? (parcera/ast input))))
-;(let [input "\\o387"]
-;  (is (parcera/failure? (parcera/ast input)))))
+    (roundtrip input))
+  (let [input "\\o432"]
+    (is (parcera/failure? (parcera/ast input))))
+  (let [input "\\o387"]
+    (is (parcera/failure? (parcera/ast input)))))
 
 (deftest AST-metadata
   (let [input    ":bar"
@@ -201,7 +200,9 @@
                 [:discard [:whitespace " "] [:number "2"]]])))
   (let [input "t2#"
         ast   (parcera/ast input)]
-    (is (= ast [:code [:symbol input]]))))
+    (is (= ast [:code [:symbol input]])))
+  (let [input "+9hello"]
+    (is (parcera/failure? (parcera/ast input)))))
 
 
 (deftest tag-literals

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -210,6 +210,7 @@
   (let [input "#a #b 1"]
     (valid? input)))
 
+
 (deftest keywords
   ;; a keyword can be a simple number because its first character is : which is
   ;; NOT a number ;)

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -137,6 +137,10 @@
   ;; edge case unicode THSP "thin space"
   (let [input "\\‘ (read-until \\’) ;; english single quotes"]
     (valid? input)
+    (roundtrip input))
+  ;; edge case, shouldnt be caught by the sentinel
+  (let [input "#{\\*\\?}"]
+    (valid? input)
     (roundtrip input)))
 
 (deftest AST-metadata

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -133,7 +133,11 @@
   (let [input "\\o432"]
     (is (parcera/failure? (parcera/ast input))))
   (let [input "\\o387"]
-    (is (parcera/failure? (parcera/ast input)))))
+    (is (parcera/failure? (parcera/ast input))))
+  ;; edge case unicode THSP "thin space"
+  (let [input "\\‘ (read-until \\’) ;; english single quotes"]
+    (valid? input)
+    (roundtrip input)))
 
 (deftest AST-metadata
   (let [input    ":bar"


### PR DESCRIPTION
- introduce a sentinel lexer rule to avoid muti-rule match on the parser
- fixes #85 
- fixes #82 
- fix: match all Unicode whitespace
- fix: dont allow any Unicode whitespace in symbols 