### PR TITLE
restrict symbol and keyword names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         # generate javascript
         - java -jar antlr-4.7.1-complete.jar -Xexact-output-dir -o src/clojure/parcera/antlr/js -package parcera.antlr -Dlanguage=JavaScript -no-listener -no-visitor src/Clojure.g4
         # pre-bundle javascript
-        - npm init --yes && npm add webpack webpack-cli antlr4
+        - npm init --yes && npm add webpack@4 webpack-cli@3 antlr4@4
         - npx webpack --config ./resources/webpack.config.js
         - lein test-runner
 
@@ -43,7 +43,7 @@ jobs:
         # generate javascript
         - java -jar antlr-4.7.1-complete.jar -Xexact-output-dir -o src/clojure/parcera/antlr/js -package parcera.antlr -Dlanguage=JavaScript -no-listener -no-visitor src/Clojure.g4
         # pre-bundle javascript
-        - npm init --yes && npm add webpack webpack-cli antlr4
+        - npm init --yes && npm add webpack@4 webpack-cli@3 antlr4@4
         - npx webpack --config ./resources/webpack.config.js
         - lein do javac, compile, check
       deploy:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject carocad/parcera "0.11.5"
+(defproject carocad/parcera "0.11.6"
   :description "Grammar-based Clojure(script) parser"
   :url "https://github.com/carocad/parcera"
   :license {:name "LGPLv3"

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -195,17 +195,23 @@ fragment ESCAPE: '\\';
 
 
 // ::/ is NOT a valid macro keyword, unlike :/
-MACRO_KEYWORD: '::' (SIMPLE_KEYWORD '/')? SIMPLE_KEYWORD;
+// multiple / are allowed for backward compatibility
+MACRO_KEYWORD: '::' (SIMPLE_KEYWORD '/'+)* SIMPLE_KEYWORD;
 
-KEYWORD: ':' (SIMPLE_KEYWORD '/')? (SIMPLE_KEYWORD | '/');
+// multiple / are allowed for backward compatibility
+KEYWORD: ':' (SIMPLE_KEYWORD '/'+)* (SIMPLE_KEYWORD | '/');
 
-// a keyword name without a namespace
-fragment SIMPLE_KEYWORD: KEYWORD_HEAD | (KEYWORD_HEAD (KEYWORD_HEAD | ':')+);
+fragment SIMPLE_KEYWORD: // a single character like + -
+                        KEYWORD_HEAD
+                        // a keyword can contain : on the body
+                        | (KEYWORD_HEAD KEYWORD_BODY+);
+
+fragment KEYWORD_BODY: KEYWORD_HEAD | ':';
 
 fragment KEYWORD_HEAD: ALLOWED_NAME_CHARACTER | DIGIT | [#'] | SIGN;
 
-
-SYMBOL: (SIMPLE_SYMBOL '/')? (SIMPLE_SYMBOL | '/');
+// multiple / are allowed for backward compatibility
+SYMBOL: (SIMPLE_SYMBOL '/'+)* (SIMPLE_SYMBOL | '/');
 
 fragment SIMPLE_SYMBOL: // a single character like + - / etc
                         (ALLOWED_NAME_CHARACTER | SIGN)

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -205,23 +205,22 @@ MACRO_KEYWORD: '::' KEYWORD_HEAD KEYWORD_BODY*;
  */
 KEYWORD: ':' ((KEYWORD_HEAD KEYWORD_BODY*) | '/');
 
-/**
- * a symbol must start with a valid character and can be followed
- * by more "relaxed" character restrictions
- *
- * This pattern matches things like: hello, hello/world, /hello/world/
- * that is by design. Parcera's grammar is more permissive than Clojure's
- * since otherwise Antlr would parse hello/world/ as
- * [:symbol "hello/world"] [:symbol "/"]
- * which is also wrong but more difficult to identify when looking at the AST
- */
-SYMBOL: '/' // edge case; / is also the namespace separator
-        // a single character like + - / etc
-        | (ALLOWED_NAME_CHARACTER | SIGN)
-        // a symbol that starts with +- cannot be followed by a number
-        | (SIGN SYMBOL_HEAD SYMBOL_BODY*)
-        // a symbol that doesnt start with +- can be followed by a number like 't2#'
-        | (ALLOWED_NAME_CHARACTER (SYMBOL_HEAD | DIGIT) SYMBOL_BODY*);
+
+SYMBOL: SIMPLE_SYMBOL ('/' SIMPLE_SYMBOL)?;
+
+fragment SIMPLE_SYMBOL: '/' // edge case; / is also the namespace separator
+                        // a single character like + - / etc
+                        | (ALLOWED_NAME_CHARACTER | SIGN)
+                        // a symbol that starts with +- cannot be followed by a number
+                        | (SIGN SYMBOL_HEAD SYMBOL_BODY*)
+                        // a symbol that doesnt start with +- can be followed by a number like 't2#'
+                        | (ALLOWED_NAME_CHARACTER (SYMBOL_HEAD | DIGIT | ':') SYMBOL_BODY*);
+
+// symbols can contain : # ' as part of their names
+fragment SYMBOL_BODY: SYMBOL_HEAD | DIGIT | ':';
+
+fragment SYMBOL_HEAD: ALLOWED_NAME_CHARACTER | [#'] | SIGN;
+
 
 // https://stackoverflow.com/a/15503680
 // used to avoid the parser matching a single invalid token as the composition

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -166,12 +166,15 @@ fragment DECIMAL: (ZERO | ([1-9] DIGIT*));
 
 fragment ZERO: '0';
 
+
 STRING: '"' ~["\\]* ('\\' . ~["\\]*)* '"';
+
 
 // any unicode whitespace "character"
 WHITESPACE: [\p{White_Space},]+;
 
 COMMENT: (';' | '#!') ~[\r\n]*;
+
 
 NAMED_CHAR: ESCAPE ('newline' | 'return' | 'space' | 'tab' | 'formfeed' | 'backspace');
 
@@ -229,16 +232,10 @@ fragment SYMBOL_HEAD: ALLOWED_NAME_CHARACTER | [#'] | SIGN;
 // of two valid tokens. Examples:
 // +9hello -> [:number +9] [:symbol hello]
 // \o423 -> [:character \o43] [:number 2]
-SENTINEL: ESCAPE? (ALLOWED_NAME_CHARACTER | DIGIT | SIGN | [/])+;
-
-fragment KEYWORD_BODY: KEYWORD_HEAD | [:/];
-
-fragment KEYWORD_HEAD: ALLOWED_NAME_CHARACTER | DIGIT | [#'] | SIGN;
-
-// symbols can contain : # ' as part of their names
-fragment SYMBOL_BODY: SYMBOL_HEAD | DIGIT | ':';
-
-fragment SYMBOL_HEAD: ALLOWED_NAME_CHARACTER | [#'/] | SIGN;
+SENTINEL: (ESCAPE (ALLOWED_NAME_CHARACTER | DIGIT)+) // invalid literal chars
+          | '::/' // invalid macro keyword
+          | (':' (ALLOWED_NAME_CHARACTER | DIGIT | SIGN | ':' | '/')+) // invalid keyword
+          | (ALLOWED_NAME_CHARACTER | DIGIT | SIGN | '/')+; // invalid symbol
 
 // these is the set of characters that are allowed by all symbols and keywords
 // however, this is more strict that necessary so that we can re-use it for both

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -195,27 +195,20 @@ fragment ESCAPE: '\\';
 
 
 // ::/ is NOT a valid macro keyword, unlike :/
-MACRO_KEYWORD: '::' KEYWORD_WILDCARD;
+MACRO_KEYWORD: '::' (SIMPLE_KEYWORD '/')? SIMPLE_KEYWORD;
 
-KEYWORD: ':' ('/' | KEYWORD_WILDCARD);
+KEYWORD: ':' (SIMPLE_KEYWORD '/')? (SIMPLE_KEYWORD | '/');
 
-fragment KEYWORD_WILDCARD: KEYWORD_HEAD // a single character like :+ :>
-                           // a keyword cannot end in : nor /
-                           | (KEYWORD_HEAD KEYWORD_HEAD)
-                           // multiple : and / are allowed inside keywords for backward compatibility
-                           // Example -> :http://www.department0.university0.edu/GraduateCourse52
-                           | (KEYWORD_HEAD KEYWORD_BODY+ KEYWORD_HEAD);
-
-fragment KEYWORD_BODY: KEYWORD_HEAD | ':' | '/';
+// a keyword name without a namespace
+fragment SIMPLE_KEYWORD: KEYWORD_HEAD | (KEYWORD_HEAD (KEYWORD_HEAD | ':')+);
 
 fragment KEYWORD_HEAD: ALLOWED_NAME_CHARACTER | DIGIT | [#'] | SIGN;
 
 
-SYMBOL: SIMPLE_SYMBOL ('/' SIMPLE_SYMBOL)?;
+SYMBOL: (SIMPLE_SYMBOL '/')? (SIMPLE_SYMBOL | '/');
 
-fragment SIMPLE_SYMBOL: '/' // edge case; / is also the namespace separator
-                        // a single character like + - / etc
-                        | (ALLOWED_NAME_CHARACTER | SIGN)
+fragment SIMPLE_SYMBOL: // a single character like + - / etc
+                        (ALLOWED_NAME_CHARACTER | SIGN)
                         // a symbol that starts with +- cannot be followed by a number
                         | (SIGN SYMBOL_HEAD SYMBOL_BODY*)
                         // a symbol that doesnt start with +- can be followed by a number like 't2#'

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -193,13 +193,14 @@ OCTAL_CHAR: ESCAPE 'o' ([0-7] | ([0-7] [0-7]) | ([0-3] [0-7] [0-7]));
 
 fragment ESCAPE: '\\';
 
+// Parcera currently (01.11.20) doesnt support multiple / inside
+// keywords nor symbols as documented in https://clojure.org/reference/reader#_symbols
+// See https://github.com/carocad/parcera/pull/94 for a more indept discussion.
 
 // ::/ is NOT a valid macro keyword, unlike :/
-// multiple / are allowed for backward compatibility
-MACRO_KEYWORD: '::' (SIMPLE_KEYWORD '/'+)* SIMPLE_KEYWORD;
+MACRO_KEYWORD: '::' (SIMPLE_KEYWORD '/')? SIMPLE_KEYWORD;
 
-// multiple / are allowed for backward compatibility
-KEYWORD: ':' (SIMPLE_KEYWORD '/'+)* (SIMPLE_KEYWORD | '/');
+KEYWORD: ':' (SIMPLE_KEYWORD '/')? (SIMPLE_KEYWORD | '/');
 
 fragment SIMPLE_KEYWORD: // a single character like + -
                         KEYWORD_HEAD
@@ -210,8 +211,7 @@ fragment KEYWORD_BODY: KEYWORD_HEAD | ':';
 
 fragment KEYWORD_HEAD: ALLOWED_NAME_CHARACTER | DIGIT | [#'] | SIGN;
 
-// multiple / are allowed for backward compatibility
-SYMBOL: (SIMPLE_SYMBOL '/'+)* (SIMPLE_SYMBOL | '/');
+SYMBOL: (SIMPLE_SYMBOL '/')? (SIMPLE_SYMBOL | '/');
 
 fragment SIMPLE_SYMBOL: // a single character like + - / etc
                         (ALLOWED_NAME_CHARACTER | SIGN)

--- a/src/Clojure.g4
+++ b/src/Clojure.g4
@@ -47,10 +47,6 @@ number: (OCTAL | HEXADECIMAL | RADIX | RATIO | LONG | DOUBLE);
 
 character: (NAMED_CHAR | OCTAL_CHAR | UNICODE_CHAR | UNICODE);
 
-/*
- * rules NOT captured in this statement:
- * - a symbol cannot be followed by another symbol "hello/world/" -> "hello/world" "/"
- */
 symbol: SYMBOL;
 
 reader_macro: ( unquote
@@ -194,16 +190,22 @@ OCTAL_CHAR: ESCAPE 'o' ([0-7] | ([0-7] [0-7]) | ([0-3] [0-7] [0-7]));
 
 fragment ESCAPE: '\\';
 
-// note: ::/ is NOT a valid macro keyword, unlike :/
-MACRO_KEYWORD: '::' KEYWORD_HEAD KEYWORD_BODY*;
 
-/*
- * Example -> :http://www.department0.university0.edu/GraduateCourse52
- *
- * technically that is NOT a valid keyword. However in order to maintain
- * backwards compatibility the Clojure team didnt remove it from LispReader
- */
-KEYWORD: ':' ((KEYWORD_HEAD KEYWORD_BODY*) | '/');
+// ::/ is NOT a valid macro keyword, unlike :/
+MACRO_KEYWORD: '::' KEYWORD_WILDCARD;
+
+KEYWORD: ':' ('/' | KEYWORD_WILDCARD);
+
+fragment KEYWORD_WILDCARD: KEYWORD_HEAD // a single character like :+ :>
+                           // a keyword cannot end in : nor /
+                           | (KEYWORD_HEAD KEYWORD_HEAD)
+                           // multiple : and / are allowed inside keywords for backward compatibility
+                           // Example -> :http://www.department0.university0.edu/GraduateCourse52
+                           | (KEYWORD_HEAD KEYWORD_BODY+ KEYWORD_HEAD);
+
+fragment KEYWORD_BODY: KEYWORD_HEAD | ':' | '/';
+
+fragment KEYWORD_HEAD: ALLOWED_NAME_CHARACTER | DIGIT | [#'] | SIGN;
 
 
 SYMBOL: SIMPLE_SYMBOL ('/' SIMPLE_SYMBOL)?;

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -190,13 +190,8 @@
   (let [input "❤️"]
     (valid? input)
     (roundtrip input))
-  ;; todo: the following test cases should fail but currently dont
-  #_(let [input "hello/world/"]
-      (is (not (valid? input))))
-  #_(let [input ":hello/world/"]
-      (is (not (valid? input))))
-  #_(let [input "::hello/world/"]
-      (is (not (valid? input))))
+  (let [input "hello/world/"]
+    (is (parcera/failure? (parcera/ast input))))
   ;; a symbol cannot start with a number
   (let [input "1#_ 2"
         ast   (parcera/ast input)]
@@ -210,7 +205,9 @@
         ast   (parcera/ast input)]
     (is (= ast [:code [:symbol input]])))
   (let [input "+9hello"]
-    (is (parcera/failure? (parcera/ast input)))))
+    (is (parcera/failure? (parcera/ast input))))
+  (let [input "A/A:0"]
+    (is (= (parcera/ast input) [:code [:symbol input]]))))
 
 
 (deftest tag-literals
@@ -241,9 +238,18 @@
     (roundtrip input))
   ;; this is NOT a valid literal keyword but it is "supported" by the current
   ;; reader
-  (let [input ":http://www.department0.university0.edu/GraduateCourse52"]
-    (valid? input)
-    (roundtrip input)))
+  (let [inputs [":http://www.department0.university0.edu/GraduateCourse52"
+                "::platform/http://www.department0.university0.edu/GraduateCourse52"
+                ":hello/world/foo"
+                ":hello/world/f:oo"
+                "::platform/foo/bar"
+                ":/"]]
+    (doseq [input inputs]
+      (valid? input)
+      (roundtrip input)))
+  (let [inputs [":hello/world/" "::hello/world/" ":7/" ":8:" "::/"]]
+    (doseq [input inputs]
+      (is (parcera/failure? (parcera/ast input))))))
 
 
 (deftest numbers

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -207,7 +207,12 @@
   (let [input "+9hello"]
     (is (parcera/failure? (parcera/ast input))))
   (let [input "A/A:0"]
-    (is (= (parcera/ast input) [:code [:symbol input]]))))
+    (is (= (parcera/ast input) [:code [:symbol input]])))
+  (let [input "hello//a/"]
+    (is (parcera/failure? (parcera/ast input))))
+  (let [input "hello///"]
+    (valid? input)
+    (roundtrip input)))
 
 
 (deftest tag-literals
@@ -246,7 +251,7 @@
     (doseq [input inputs]
       (valid? input)
       (roundtrip input)))
-  (let [inputs [":hello/world/" "::hello/world/" ":7/" ":8:"]]
+  (let [inputs [":hello/world/" "::hello/world/" ":7/"]]
     (doseq [input inputs]
       (is (parcera/failure? (parcera/ast input))))))
 

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -242,12 +242,11 @@
                 "::platform/http://www.department0.university0.edu/GraduateCourse52"
                 ":hello/world/foo"
                 ":hello/world/f:oo"
-                "::platform/foo/bar"
-                ":/"]]
+                "::platform/foo/bar"]]
     (doseq [input inputs]
       (valid? input)
       (roundtrip input)))
-  (let [inputs [":hello/world/" "::hello/world/" ":7/" ":8:" "::/"]]
+  (let [inputs [":hello/world/" "::hello/world/" ":7/" ":8:"]]
     (doseq [input inputs]
       (is (parcera/failure? (parcera/ast input))))))
 

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -208,11 +208,14 @@
     (is (parcera/failure? (parcera/ast input))))
   (let [input "A/A:0"]
     (is (= (parcera/ast input) [:code [:symbol input]])))
-  (let [input "hello//a/"]
-    (is (parcera/failure? (parcera/ast input))))
-  (let [input "hello///"]
-    (valid? input)
-    (roundtrip input)))
+  ;; todo: the followings are NOT valid literal symbols but they are
+  ;; "supported" by the current LispReader implementation
+  ;; hopefully in the future it won't; see CLJ-1530
+  #_(let [input "hello//a/"]
+      (is (parcera/failure? (parcera/ast input))))
+  #_(let [input "hello///"]
+      (valid? input)
+      (roundtrip input)))
 
 
 (deftest tag-literals
@@ -241,17 +244,20 @@
   (let [input ":#hello"]
     (valid? input)
     (roundtrip input))
-  ;; this is NOT a valid literal keyword but it is "supported" by the current
-  ;; reader
+  ;; todo: the followings are NOT valid literal keyword but they are
+  ;; "supported" by the current LispReader implementation
+  ;; hopefully in the future it won't; see CLJ-1530
   (let [inputs [":http://www.department0.university0.edu/GraduateCourse52"
                 "::platform/http://www.department0.university0.edu/GraduateCourse52"
                 ":hello/world/foo"
                 ":hello/world/f:oo"
-                "::platform/foo/bar"]]
-    (doseq [input inputs]
-      (valid? input)
-      (roundtrip input)))
-  (let [inputs [":hello/world/" "::hello/world/" ":7/"]]
+                "::platform/foo/bar"
+                #_(doseq [input inputs]
+                    (valid? input)
+                    (roundtrip input))
+                ":hello/world/"
+                "::hello/world/"
+                ":7/"]]
     (doseq [input inputs]
       (is (parcera/failure? (parcera/ast input))))))
 

--- a/test/parcera/test_cases.cljc
+++ b/test/parcera/test_cases.cljc
@@ -47,14 +47,14 @@
   "The grammar definition of parcera is valid for any clojure value. Meaning
   that for any clojure value, parcera can create an AST for it"
   (prop/for-all [input (gen/fmap pr-str gen/any)]
-    (valid? input)))
+    (not (parcera/failure? (parcera/ast input)))))
 
 
 (def symmetric
   "The read <-> write process of parcera MUST be symmetrical. Meaning
   that the AST and the text representation are equivalent"
   (prop/for-all [input (gen/fmap pr-str gen/any)]
-    (roundtrip input)))
+    (= input (parcera/code (parcera/ast input)))))
 
 
 (def monotonic


### PR DESCRIPTION
- ~fix: only allow a single `/` inside symbols~ not possible in order to maintain backward compatibility of Clojure code. See comments below
- fix: `:` is a valid character inside a symbol
- fix: keywords cannot end with `/`